### PR TITLE
Waterfall: Use NoFormatConversion with fromImage

### DIFF
--- a/src/waterfall.cpp
+++ b/src/waterfall.cpp
@@ -153,7 +153,7 @@ void Waterfall::paint(QPainter *painter)
     }
 
     // http://blog.qt.io/blog/2006/05/13/fast-transformed-pixmapimage-drawing/
-    pix = QPixmap::fromImage(_image);
+    pix = QPixmap::fromImage(_image, Qt::NoFormatConversion);
     // Code for debug, draw the entire waterfall
     //_painter->drawPixmap(_painter->viewport(), pix, QRect(0, 0, _image.width(), _image.height()));
     _painter->drawPixmap(_painter->viewport(), pix, QRect(first, 0, displayWidth, _maxDepthToDrawInPixels));


### PR DESCRIPTION
From: http://lists.qt-project.org/pipermail/interest/2015-October/019264.html
> Converting that to a QPixmap will entail a QImage::convertToFormat() to map the image into a system specific pixel format, usually QImage::RGB32 or
> QImage::ARGB32_Premultiplied, but any given QPA backend may override that with an other format if that is more compatible with its raster backingstore.

This approach reduce CPU usage in 27%

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>