### PR TITLE
LogListModel corrections

### DIFF
--- a/src/loglistmodel.cpp
+++ b/src/loglistmodel.cpp
@@ -1,5 +1,11 @@
 #include "loglistmodel.h"
 
+LogListModel::LogListModel(QObject* parent)
+    : QStringListModel(parent)
+{
+    _roleNames.unite(QStringListModel::roleNames());
+}
+
 QVariant LogListModel::data(const QModelIndex & index, int role) const
 {
     switch (role) {
@@ -44,8 +50,5 @@ bool LogListModel::setData(const QModelIndex & index, const QVariant & value, in
 
 QHash<int, QByteArray> LogListModel::roleNames() const
 {
-    QHash<int, QByteArray> ret = QStringListModel::roleNames();
-    ret.insert(Qt::ForegroundRole, "foreground");
-    ret.insert(LogListModel::TimeRole, "time");
-    return ret;
+    return _roleNames;
 }

--- a/src/loglistmodel.cpp
+++ b/src/loglistmodel.cpp
@@ -26,20 +26,14 @@ QVariant LogListModel::data(const QModelIndex & index, int role) const
 
 bool LogListModel::setData(const QModelIndex & index, const QVariant & value, int role)
 {
-    QVector<int> roles(4);
-    roles.append(Qt::DisplayRole);
-    roles.append(Qt::EditRole);
-    roles.append(Qt::ForegroundRole);
-    roles.append(LogListModel::TimeRole);
-
     switch (role) {
     case (Qt::ForegroundRole) :
         _rowColors[index.row()] = value.value<QColor>();
-        emit dataChanged(index, index, roles);
+        emit dataChanged(index, index, _roles);
         return true;
     case (LogListModel::TimeRole) :
         _rowTimes[index.row()] = value.toString();
-        emit dataChanged(index, index, roles);
+        emit dataChanged(index, index, _roles);
         return true;
     default :
         break;

--- a/src/loglistmodel.h
+++ b/src/loglistmodel.h
@@ -16,9 +16,7 @@ public:
      *
      * @param parent
      */
-    LogListModel(QObject* parent = nullptr)
-        : QStringListModel(parent)
-    {}
+    LogListModel(QObject* parent = nullptr);
 
     enum { TimeRole = Qt::UserRole + 0x10 };
 
@@ -53,6 +51,10 @@ private:
     QVector<int> _roles{
         Qt::ForegroundRole,
         LogListModel::TimeRole,
+    };
+    QHash<int, QByteArray> _roleNames{
+        {{Qt::ForegroundRole}, {"foreground"}},
+        {{LogListModel::TimeRole}, {"time"}},
     };
     std::map<int, QColor> _rowColors;
     std::map<int, QString> _rowTimes;

--- a/src/loglistmodel.h
+++ b/src/loglistmodel.h
@@ -50,6 +50,10 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
 private:
+    QVector<int> _roles{
+        Qt::ForegroundRole,
+        LogListModel::TimeRole,
+    };
     std::map<int, QColor> _rowColors;
     std::map<int, QString> _rowTimes;
 };


### PR DESCRIPTION
- Move const variables that belong to model struct to private variables.
  - They are defined only once
  - They define how the entire model will work, makes more sense to move it to header