### PR TITLE
Use Ping and not Sensor in QML, fix #212

### DIFF
--- a/src/sensor/ping.cpp
+++ b/src/sensor/ping.cpp
@@ -89,7 +89,7 @@ Ping::Ping() : Sensor()
 void Ping::connectLink(const QStringList& connString)
 {
     if(_detector.isRunning()) {
-        _detector.exit();
+        _detector.requestInterruption();
     }
     setAutoDetect(false);
     QStringList logConnString{

--- a/src/sensor/ping.h
+++ b/src/sensor/ping.h
@@ -28,7 +28,7 @@ public:
      *
      * @param connString Connection string defined as (int:string:arg)
      */
-    void connectLink(const QStringList& connString);
+    Q_INVOKABLE void connectLink(const QStringList& connString);
 
     /**
      * @brief debug function

--- a/src/sensor/sensor.h
+++ b/src/sensor/sensor.h
@@ -47,15 +47,14 @@ public:
      * @param connString Connection string defined as (int:string:arg)
      * @param logConnString Log connection string defined as (int:string:arg)
      */
-    Q_INVOKABLE void connectLink(QStringList connString, const QStringList& logConnString = QStringList());
+    void connectLink(QStringList connString, const QStringList& logConnString = QStringList());
 
     /**
      * @brief Add log link
      *
      * @param connString Log connection string defined as (int:string:arg)
-     * @return Q_INVOKABLE connectLinkLog
      */
-    Q_INVOKABLE void connectLinkLog(QStringList connString);
+    void connectLinkLog(QStringList connString);
 
     /**
      * @brief Set auto detect


### PR DESCRIPTION
- Needs https://github.com/bluerobotics/ping-protocol-cpp/pull/49
- Fix #212 
- Moves Ping and not Sensor to be visible for qml