### PR TITLE
Use general request

### DIFF
--- a/src/sensor/ping.cpp
+++ b/src/sensor/ping.cpp
@@ -489,8 +489,8 @@ void Ping::request(int id)
     }
     qCDebug(PING_PROTOCOL_PING) << "Requesting:" << id;
 
-    ping_msg_ping1D_empty m;
-    m.set_id(id);
+    ping_msg_ping1D_general_request m;
+    m.set_requested_id(id);
     m.updateChecksum();
     writeMessage(m);
 


### PR DESCRIPTION
~~general_request fail with id 1214.~~
It's working fine with 3.26
https://github.com/bluerobotics/ping-protocol/pull/113 need to be merged first.