### PR TITLE
pingfiledialog: Move from QtQuick 2.12 to 2.11

### DIFF
--- a/qml/PingFileDialog.qml
+++ b/qml/PingFileDialog.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.12
+import QtQuick 2.11
 import QtQuick.Dialogs 1.3
 
 Item {


### PR DESCRIPTION
We are building the binaries with Qt 5.11

fix #373 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>