### PR TITLE
compile: Correct AppImage deploy name

### DIFF
--- a/tools/compile.sh
+++ b/tools/compile.sh
@@ -193,7 +193,7 @@ if [[ $machine = *"Linux"* ]]; then
     runstep "chmod a+x /tmp/linuxdeployqt.AppImage" "Convert linuxdeployqt to executable" "Failed to turn linuxdeplopyqt in executable"
     runstep "unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH;" "Unset some Qt variables" "Failed to unsed Qt variables"
     runstep "/tmp/linuxdeployqt.AppImage ${deployfolder}/pingviewer.desktop -unsupported-allow-new-glibc -bundle-non-qt-libs -extra-plugins=imageformats/libqsvg.so -verbose=2 -qmldir=${projectpath}/qml -appimage" "Run linuxdeployqt" "Failed to run linuxdeployqt"
-    runstep "mv pingviewer*.AppImage /tmp/" "Move .AppImage folder to /tmp/" "Faile to move .AppImage file"
+    runstep "mv pingviewer*.AppImage /tmp/pingviewer-x86_64.AppImage" "Move .AppImage folder to /tmp/" "Faile to move .AppImage file"
 else
     runstep "wget https://github.com/bluerobotics/stm32flash-code/releases/download/continuous/stm32flash_linux.zip -O /tmp/stm32flash_linux.zip" "Download stm32flash_linux" "Faile to download stm32flash_linux"
     runstep "unzip /tmp/stm32flash_linux.zip  -d /tmp" "Unzip stm32flash" "Fail to unzip stm32flash"


### PR DESCRIPTION
Fix #396

Last version of linuxdeployqt adds commit hash name in the name of the file
Such thing creates a huge number of files in S3

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>