### PR TITLE
[WIP] depthaxis: add extended ticks

### DIFF
--- a/qml/DepthAxis.qml
+++ b/qml/DepthAxis.qml
@@ -82,6 +82,30 @@ Item {
     }
 
     Component {
+        id: extendedTickMark
+        RowLayout {
+            anchors.right: parent.right
+            height: lastIndex ? remainingHeight() : nominalHeight()
+            width: root.width
+
+            Layout.fillHeight: true
+            Layout.alignment: Qt.AlignRight | Qt.AlignBottom
+
+            property var lastIndex: (index + 1) == numTicks
+                Rectangle {
+                    id: extendedTick
+                    width: root.width
+                    height: 1
+                    Layout.alignment: Qt.AlignRight | Qt.AlignBottom
+                    color: root.color
+                    border.color: root.color
+                    border.width: 1
+                    visible: parent.height > 0
+                }
+        }
+    }
+
+    Component {
         id: tickLabel
         RowLayout {
             anchors.right: parent.right
@@ -121,6 +145,14 @@ Item {
         Repeater {
             model: numTicks
             delegate: tickMark
+        }
+    }
+
+    Column {
+        anchors.fill:parent
+        Repeater {
+            model: numTicks
+            delegate: extendedTickMark
         }
     }
 

--- a/qml/Ping1DVisualizer.qml
+++ b/qml/Ping1DVisualizer.qml
@@ -87,6 +87,7 @@ Item {
             DepthAxis {
                 id: depthAxis
                 anchors.fill: parent
+                width: waterfall.width
                 start_mm: waterfall.minDepthToDraw
                 end_mm: waterfall.maxDepthToDraw
                 visible: start_mm != end_mm


### PR DESCRIPTION
I'd like to add a shortcut to toggle 'extended ticks'. There's some problem with the anchoring/width binding in 17cc7d8.

![screenshot_20190116_125247](https://user-images.githubusercontent.com/8315108/51268508-47abc280-198e-11e9-9b5e-275d66529ffb.png)
