### PR TITLE
Improve todo notation

### DIFF
--- a/src/sensor/ping.cpp
+++ b/src/sensor/ping.cpp
@@ -250,7 +250,7 @@ void Ping::handleMessage(PingMessage msg)
         _scan_length = m.scan_length();
         _gain_index = m.gain_index();
 
-        // TODO, change to distMsgUpdate() or similar
+        // TODO: change to distMsgUpdate() or similar
         emit distanceUpdate();
         emit pingNumberUpdate();
         emit confidenceUpdate();
@@ -289,7 +289,7 @@ void Ping::handleMessage(PingMessage msg)
             _points.replace(i, m.profile_data()[i] / 255.0);
         }
 
-        // TODO, change to distMsgUpdate() or similar
+        // TODO: change to distMsgUpdate() or similar
         emit distanceUpdate();
         emit pingNumberUpdate();
         emit confidenceUpdate();
@@ -380,7 +380,7 @@ void Ping::handleMessage(PingMessage msg)
         break;
     }
 
-    // TODO is this signalling expensive?
+    // TODO: is this signalling expensive?
     // we can cut down on this a lot in general
     _dstId = msg.dst_device_id();
     _srcId = msg.src_device_id();

--- a/src/sensor/ping.h
+++ b/src/sensor/ping.h
@@ -395,9 +395,9 @@ public:
      */
     int parsedMsgs() { return _parser ? _parser->parsed : 0; }
     Q_PROPERTY(int parsed_msgs READ parsedMsgs NOTIFY parsedMsgsUpdate)
-    // TODO, maybe store history/filtered history of values in this
+    // TODO: maybe store history/filtered history of values in this
     // object for access by different visual elements without need to recompute
-    // TODO install filters here?
+    // TODO: install filters here?
 
     /**
      * @brief Return the number of messages that we requested and did not received
@@ -519,7 +519,7 @@ private:
 
     static const uint16_t _num_points = 200;
 
-    // TODO maybe use vector or uint8_t[] here
+    // TODO: maybe use vector or uint8_t[] here
     // QVector is only required if points need to be exposed to qml
     //QVector<int> _points;
     QVector<double> _points;
@@ -528,7 +528,7 @@ private:
     uint16_t _ping_interval = 0;
     static const int _pingMaxFrequency;
 
-    // TODO const &
+    // TODO: const &
     void handleMessage(PingMessage msg); // handle incoming message
     void writeMessage(const PingMessage& msg); // write a message to link
 

--- a/src/sensor/sensor.cpp
+++ b/src/sensor/sensor.cpp
@@ -36,7 +36,7 @@ Sensor::Sensor() :
     });
 }
 
-// TODO rework this after sublasses and parser rework
+// TODO: rework this after sublasses and parser rework
 void Sensor::connectLink(const LinkConfiguration& conConf, const LinkConfiguration& logConf)
 {
     if(_detector->isRunning()) {

--- a/src/sensor/sensor.h
+++ b/src/sensor/sensor.h
@@ -6,7 +6,7 @@
 #include "parsers/parser.h"
 #include "protocoldetector.h"
 
-// TODO rename to Device?
+// TODO: rename to Device?
 /**
  * @brief Manage sensor connection
  *
@@ -103,7 +103,7 @@ protected:
     QSharedPointer<Link> _linkOut;
     Parser* _parser; // communication implementation
 
-    QString _name; // TODO populate
+    QString _name; // TODO: populate
 
 signals:
     void autoDetectUpdate(bool autodetect);

--- a/src/sensor/sensorarbitrary.h
+++ b/src/sensor/sensorarbitrary.h
@@ -37,7 +37,7 @@ signals:
 
 private:
     Q_DISABLE_COPY(SensorArbitrary)
-    // TODO maybe QMap<QString, QVariant>
+    // TODO: maybe QMap<QString, QVariant>
     QString _name;
     QVariant _value;
 

--- a/src/waterfall/waterfall.cpp
+++ b/src/waterfall/waterfall.cpp
@@ -300,7 +300,7 @@ void Waterfall::draw(const QVector<double>& points, float confidence, float init
     int virtualHeight = length*_minPixelsPerMeter*dynamicPixelsPerMeterScalar;
 
     // Copy tail to head
-    // TODO can we get even better and allocate just once at initialization? ie circular buffering
+    // TODO: can we get even better and allocate just once at initialization? ie circular buffering
     if (currentDrawIndex >= _image.width()) {
         //Swap is faster
         _image.swap(old);


### PR DESCRIPTION
Use `TODO:` and not `todo`, `todo,` or any variation

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>