### PR TITLE
project: use git tag instead of git describe in order to find all

### DIFF
--- a/pingviewer.pro
+++ b/pingviewer.pro
@@ -66,7 +66,7 @@ message("Check for GIT version and tag:")
 exists ($$_PRO_FILE_PWD_/.git) {
     GIT_VERSION = $$system(git --git-dir $$_PRO_FILE_PWD_/.git --work-tree $$PWD log -1 --format=%h)
     GIT_VERSION_DATE = $$system(git --git-dir $$_PRO_FILE_PWD_/.git --work-tree $$PWD log -1 --format=%aI)
-    GIT_TAG = $$system(git --git-dir $$_PRO_FILE_PWD_/.git --work-tree $$PWD describe --tags --exclude "continuous*" --exact-match)
+    GIT_TAG = $$system(git --git-dir $$_PRO_FILE_PWD_/.git --work-tree $$PWD tag --points-at HEAD | grep -v continuous | grep -v stable)
     GIT_URL = $$system(git --git-dir $$_PRO_FILE_PWD_/.git --work-tree $$PWD remote get-url origin)
     DEFINES += 'GIT_VERSION=\\"$$GIT_VERSION\\"'
     DEFINES += 'GIT_VERSION_DATE=\\"$$GIT_VERSION_DATE\\"'

--- a/src/network/networktool.cpp
+++ b/src/network/networktool.cpp
@@ -56,11 +56,12 @@ void NetworkTool::checkNewVersionInGitHubPayload(const QJsonDocument& jsonDocume
     QRegularExpressionMatch regexMatch = releaseTagRegex.match(projectTag);
     // Check if this actual version is a real release (normal or test)
     // Alarm people to download the correction version !
-    int actualVersion = regexMatch.hasMatch() ? semverToInt(projectTag) : -1.0;
+    // strip leading character with .mid(1)
+    int actualVersion = regexMatch.hasMatch() ? semverToInt(projectTag.mid(1)) : -1.0;
 
     // If this version does not follow vd+.d+.d+, this is a test or continuous release
     if(regexMatch.hasMatch()) {
-        qCDebug(NETWORKTOOL) << "Running release version:" << projectTag;
+        qCDebug(NETWORKTOOL) << "Running release version:" << projectTag << "#" << actualVersion;
     } else {
         releaseTagRegex.setPattern(QStringLiteral(R"([t,v]\d+\.\d+\.\d+)"));
         qCDebug(NETWORKTOOL) << "Running test version:" << projectTag;
@@ -92,7 +93,9 @@ void NetworkTool::checkNewVersionInGitHubPayload(const QJsonDocument& jsonDocume
         }
         qCDebug(NETWORKTOOL) << "Possible new version.";
 
+        // strip leading character with .mid(1)
         auto version = semverToInt(versionString.mid(1));
+        qCDebug(NETWORKTOOL) << "comparing version:" << versionString << "#" << version;
         if(version > lastReleaseAvailable.version) {
             lastReleaseAvailable.version = version;
             lastReleaseAvailable.versionString = versionString;


### PR DESCRIPTION
fix #442 
This will show only commits with tags that do not contain 'continuous' or 'stable' in the name.