### PR TITLE
ping: Fix confidence type

### DIFF
--- a/src/sensor/ping.h
+++ b/src/sensor/ping.h
@@ -487,7 +487,7 @@ private:
     uint16_t _firmware_version_minor = 0;
 
     uint32_t _distance = 0; // mm
-    uint8_t _confidence = 0; // 0-100%
+    uint16_t _confidence = 0; // 0-100%
     uint16_t _pulse_duration = 0;
     uint32_t _ping_number = 0;
     uint32_t _scan_start = 0;


### PR DESCRIPTION
In some messages (1212, 1300) confidence is uint16_t and in others (1211) is uint8_t

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>