### PR TITLE
Fix wrong input when input loses focus

### DIFF
--- a/qml/ConnectionMenu.qml
+++ b/qml/ConnectionMenu.qml
@@ -184,9 +184,10 @@ Item {
                     Layout.columnSpan:  2
                     Layout.fillWidth: true
                     onEditingFinished: {
-                        if (input == "0.0.0.0" || input == "localhost") {
+                        if (text === "0.0.0.0" || text === "localhost") {
                             text = "127.0.0.1"
                         }
+
                         connect(AbstractLinkNamespace.Udp, text, udpPort.text)
                     }
                 }
@@ -197,7 +198,7 @@ Item {
                     Layout.columnSpan:  2
                     Layout.fillWidth: true
                     onEditingFinished: {
-                        connect(AbstractLinkNamespace.Udp, udpIp.text, udpPort.text)
+                        connect(AbstractLinkNamespace.Udp, udpIp.text, text)
                     }
                 }
             }

--- a/qml/MainMenu.qml
+++ b/qml/MainMenu.qml
@@ -76,7 +76,7 @@ Item {
                         Layout.columnSpan: 2
                         Layout.fillWidth: true
                         onEditingFinished: {
-                            var speed_of_sound = parseFloat(input)
+                            var speed_of_sound = parseFloat(text)
                             ping.speed_of_sound = speed_of_sound * 1000 // mm/s
                         }
                     }
@@ -223,7 +223,7 @@ Item {
                         Layout.columnSpan: 2
                         Layout.fillWidth: true
                         onEditingFinished: {
-                            parent.setDepth(parseInt(input), ping.length_mm)
+                            parent.setDepth(parseInt(text), ping.length_mm)
                         }
                     }
 
@@ -238,7 +238,7 @@ Item {
                         Layout.columnSpan: 2
                         Layout.fillWidth: true
                         onEditingFinished: {
-                            parent.setDepth(ping.start_mm, parseInt(input))
+                            parent.setDepth(ping.start_mm, parseInt(text))
                         }
                     }
                 }

--- a/qml/PingTextField.qml
+++ b/qml/PingTextField.qml
@@ -13,7 +13,7 @@ Item {
     height: label.height
 
     // Emited when edition if finished with enter/return key or when TextField loses focus
-    signal editingFinished(var input)
+    signal editingFinished()
 
     // This avoid connection interactions while user input is on
     onTextChanged: {
@@ -38,13 +38,23 @@ Item {
         anchors.leftMargin: 5
         selectByMouse: true
 
-        onEditingFinished: {
+        // editingFinished() is only emitted when TextField has focus
+        // That's why we are using accepted()
+        onAccepted: {
             focus = false
             mainPage.forceActiveFocus()
-            root.editingFinished(textField.text)
+            // It's necessary to update the input variable
+            root.text = textField.text
+            root.editingFinished()
         }
 
         onActiveFocusChanged: {
+            // TODO: We should update the user about wrong inputs here
+            // This allow us to correct not valid inputs to the last valid value
+            if(!acceptableInput) {
+                textField.text = root.text
+            }
+
             if (activeFocus) {
                 selectAll()
             } else {

--- a/qml/PingTextField.qml
+++ b/qml/PingTextField.qml
@@ -5,12 +5,12 @@ import QtQuick.Layouts 1.3
 
 Item {
     id: root
-    property alias title: text.text
+    property alias title: label.text
     property var text: ""
     property alias validator: textField.validator
 
-    width: text.width + textField.width
-    height: text.height
+    width: label.width + textField.width
+    height: label.height
 
     // Emited when edition if finished with enter/return key or when TextField loses focus
     signal editingFinished(var input)
@@ -21,20 +21,20 @@ Item {
             return
         }
 
-        textField.text = root.text
+        textField.text = text
     }
 
 
     Label {
-        id: text
+        id: label
         color: Material.accent
     }
 
     TextField {
         id: textField
 
-        anchors.left: text.right
-        anchors.baseline: text.baseline
+        anchors.left: label.right
+        anchors.baseline: label.baseline
         anchors.leftMargin: 5
         selectByMouse: true
 

--- a/qml/PingTextField.qml
+++ b/qml/PingTextField.qml
@@ -6,7 +6,7 @@ import QtQuick.Layouts 1.3
 Item {
     id: root
     property alias title: label.text
-    property var text: ""
+    property string text: ""
     property alias validator: textField.validator
 
     width: label.width + textField.width


### PR DESCRIPTION
TextField with validators does not emit onAccept or onEditingFinished when wrong inputs are in the TextField. We need to check if the focus was lost and the input is valid manually.

onEditingFinished is only emitted when TextField has focus, otherwise will not emit. That's why I'm moving to on Accept, this one will be emitted if the application loses focus or enter is emitted. 

Input variable from onEditingFinished was removed to use old/classic implementation of text variable after fixing logic problems with new implementation. 