### PR TITLE
ConnectionMenu: Uses 115200 as default baudrate option

### DIFF
--- a/qml/ConnectionMenu.qml
+++ b/qml/ConnectionMenu.qml
@@ -159,7 +159,7 @@ Item {
 
                 ComboBox {
                     id: baudrateBox
-                    model: [9600, 115200]
+                    model: [115200, 9600]
                     onActivated: {
                         connect(AbstractLinkNamespace.Serial, serialPortsCB.currentText, baudrateBox.currentText)
                     }


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>