### PR TITLE
tools: Add periodic print of '.' to avoid travis timeout issue

### DIFF
--- a/tools/compile.sh
+++ b/tools/compile.sh
@@ -71,7 +71,11 @@ runstep() {
     okmessage=$2
     errormsg=$3
     printfb "$okmessage: "
+
+    # This prints a '.' while the command is evaluated
+    sh -c "while sleep 1; do printf '.'; done;" &
     eval "$1" >>$verboseoutput 2>&1
+    kill $!
     [ $? == 0 ] || {
         echob "✖"
         cat $verboseoutput


### PR DESCRIPTION
Travis result in timeout if there is no output in 10min
LinuxDeployQt takes more than 10min to do the package sometimes

Fix [#486](https://github.com/bluerobotics/ping-viewer/issues/486)

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>

![image](https://user-images.githubusercontent.com/1215497/55403874-2b4f0900-552d-11e9-864f-055062ea6f12.png)
