### PR TITLE
Replace html images with markdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 script:
   - git remote set-url origin https://${GITHUB_TOKEN}@github.com/bluerobotics/ping-viewer
   - mkdocs build
-  - htmlproofer --empty-alt-ignore --file-ignore "./site/404.html" --url-ignore "https://fonts.gstatic.com" || travis_terminate 1
+  - htmlproofer --empty-alt-ignore --file-ignore "./site/404.html" --url-ignore "https://fonts.gstatic.com" site || travis_terminate 1
   - if [ ${TRAVIS_PULL_REQUEST} == "false" ]; then
       mkdocs gh-deploy --force;
     fi

--- a/docs/application-information.md
+++ b/docs/application-information.md
@@ -6,9 +6,7 @@
 4. [**Application log**](#application-log)
 5. [**Log categories**](#log-categories)
 
-<p align="center">
-    <img src="../images/viewer/annotated/application-information-annotated.png">
-</p>
+![Application information annotated](/images/viewer/annotated/application-information-annotated.png)
 
 #### Application software information
 
@@ -19,10 +17,10 @@ This area shows information about the Ping Viewer application software version.
 This area shows information about the connected device.
 
 #### Header buttons
-- ![](images/icons/lock.png) Scroll lock for log window
-- ![](images/icons/chat.png) [Blue Robotics Forum](https://discuss.bluerobotics.com)
-- ![](images/icons/report.png) [Bug reports and feature requests](https://github.com/bluerobotics/ping-viewer/issues)
-- ![](images/icons/settings.png) Reset application settings
+- ![](/images/icons/lock.png) Scroll lock for log window
+- ![](/images/icons/chat.png) [Blue Robotics Forum](https://discuss.bluerobotics.com)
+- ![](/images/icons/report.png) [Bug reports and feature requests](https://github.com/bluerobotics/ping-viewer/issues)
+- ![](/images/icons/settings.png) Reset application settings
 
 #### Application log
 

--- a/docs/connection-settings.md
+++ b/docs/connection-settings.md
@@ -5,9 +5,7 @@ PingViewer also attempts to connect to UDP port 9090 on the host at IP address 1
 The Ping device connection can also be configured explicitly in the Connection Settings menu:
 
 TODO take new shot without sonar type
-<p align="center">
-    <img src="../images/viewer/connection-settings.png">
-</p>
+![Connection Settings](/images/viewer/connection-settings.png)
 
 ## Connection Types
 

--- a/docs/css/center_images.css
+++ b/docs/css/center_images.css
@@ -1,0 +1,4 @@
+article p img {
+    display: block;
+    margin: 0 auto;
+}

--- a/docs/device-settings.md
+++ b/docs/device-settings.md
@@ -1,6 +1,4 @@
-<p align="center">
-    <img src="../images/viewer/ping-settings.png">
-</p>
+![Ping Settings](/images/viewer/ping-settings.png)
 
 ## Menu Items
 

--- a/docs/display-settings.md
+++ b/docs/display-settings.md
@@ -1,6 +1,4 @@
-<p align="center">
-    <img src="../images/viewer/display-settings.png">
-</p>
+![Display Settings](/images/viewer/display-settings.png)
 
 ## Menu Items
 

--- a/docs/faq-and-troubleshooting.md
+++ b/docs/faq-and-troubleshooting.md
@@ -26,19 +26,13 @@ Ping Viewer should run on any modern computer.
     If no serial device appears in Ping Viewer while connected to the computer, download and install [Windows FTDI VCP Driver Executable](https://cdn.sparkfun.com/assets/learn_tutorials/7/4/CDM21228_Setup.exe).
 
     1. Allow any question related to the software publisher or disk modifications.
-    <p align="center">
-    <img src="https://i.imgur.com/rqY8YJA.jpg">
-    </p>
+    ![Smart Screen](https://i.imgur.com/rqY8YJA.jpg)
 
     2. Follow the installation procedure.
-    <p align="center">
-    <a href="http://i.imgur.com/r2psVwz.jpg">
-        <img src="https://imgur.com/r2psVwz.jpg">
-    </a>
-    </p>
+    
+    [![FTDI Install Steps](https://imgur.com/r2psVwz.jpg)](https://imgur.com/r2psVwz.jpg)
 
     3. After finishing the installation, restart you computer and run Ping Viewer, the serial port should appear.
 
-    <p align="center">
-    <img src="https://i.imgur.com/yKfPuJx.jpg">
-    </p>
+    ![Connection Configuration](https://i.imgur.com/yKfPuJx.jpg)
+

--- a/docs/firmware-update.md
+++ b/docs/firmware-update.md
@@ -1,6 +1,4 @@
-<p align="center">
-    <img src="../images/viewer/firmware-update.png">
-</p>
+![Firmware Update](/images/viewer/firmware-update.png)
 
 The Firmware Update menu allows you to update the programming on a Ping device.
 
@@ -14,9 +12,7 @@ Steps to flash the device:
 
 > Wait for the update process to complete before unplugging the device!
 
-<p align="center">
-    <img src="../images/viewer/firmware-update-waiting.gif">
-</p>
+![Firmware Update Waiting](/images/viewer/firmware-update-waiting.gif)
 
 ## Device recovery
 
@@ -26,9 +22,7 @@ The device must be opened to restore the firmware. We only want to open the devi
 
 To open the device, hold it firmly, and turn the blue ring in counterclockwise direction:
 
-<p align="center">
-    <img src="../images/firmware-update/open-ping.png">
-</p>
+![Firmware Update Waiting](/images/firmware-update/open-ping.png)
 
 After the device is opened, turn it on and look for a blinking led on the circuit board inside of the device. If you see a blinking led, the device should be good and the firmware is running fine, you may close the device and double check the [troubleshooting instructions](http://docs.bluerobotics.com/ping-viewer/faq-and-troubleshooting/#troubleshooting).
 
@@ -42,9 +36,9 @@ If the led is not blinking:
    - On mac/linux: `wget "https://raw.githubusercontent.com/bluerobotics/ping-firmware/master/ping1d/Ping_V3.26_115kb.hex"`
  - With the device open, you should see a BOOT button in the main board. Power down the device, press and hold this button down, then power the device and let go of the button
  - You should check the port of the device with windows **Device Manager** or with `dmesg` on linux.
- <p align="center">
-    <img src="../images/firmware-update/device-manager.png">
-</p>
+
+ ![Firmware Update Waiting](/images/firmware-update/device-manager.png)
+
  - After finding the port (`COMx` on windows and `/dev/ttyUSB*` on linux) you can start the flash procedure.
  - In the same terminal type:
    - On windows `.\stm32flash.exe -v -g 0x0 -b 115200 -w .\Ping_V3.26_115kb.hex COM4`

--- a/docs/firmware-update.md
+++ b/docs/firmware-update.md
@@ -27,6 +27,7 @@ To open the device, hold it firmly, and turn the blue ring in counterclockwise d
 After the device is opened, turn it on and look for a blinking led on the circuit board inside of the device. If you see a blinking led, the device should be good and the firmware is running fine, you may close the device and double check the [troubleshooting instructions](http://docs.bluerobotics.com/ping-viewer/faq-and-troubleshooting/#troubleshooting).
 
 If the led is not blinking:
+
  - Open the folder where the ping-viewer executable binary is located
  - Copy the folder path (we will use `/folder/path` in this example)
  - Open your OS terminal. (powershell on windows, what you prefer on linux :) )

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,31 +19,21 @@ Follow the setup instructions for your operating system:
 
 Download [this .zip file](https://github.com/bluerobotics/ping-viewer/releases/download/stable/pingviewer_release.zip), open the download location in the File Explorer, and extract it. Open the application by double clicking the executable file (pingviewer.exe). Windows will ask you to trust the software; click **More Info** → **Run Anyway**.
 
-<p align="center">
-  <img src="images/install/windows-protected-your-pc.png">
-</p>
+![Windows protected your PC screen](/images/install/windows-protected-your-pc.png)
 
 ### Mac
 
 Download [this .dmg file](https://github.com/bluerobotics/ping-viewer/releases/download/stable/pingviewer-release.dmg), and double click it to open. Drag the Ping Viewer application icon to your *Applications* folder. Open the application by double clicking the icon in your *Applications* folder.
 
-<p align="center">
-  <img src="images/install/mac-install-from-dmg.jpg">
-</p>
+![Install from .dmg](/images/install/mac-install-from-dmg.jpg)
 
 If you get an 'unidentified developer' notification when you try to open the application, you may adjust your security preferences to allow the application to run. Visit **System Preferences** -> **Security and Privacy**, click the lock and enter your password to make changes, then click 'Open Anyway'.
 
-<p align="center">
-  <img src="images/install/mac-unidentified-developer.png">
-</p>
+![Mac Unindentified Developer](/images/install/mac-unidentified-developer.png)
 
-<p align="center">
-  <img src="images/install/mac-system-preferences-annotated.png">
-</p>
+![Mac System Preferences](/images/install/mac-system-preferences-annotated.png)
 
-<p align="center">
-  <img src="images/install/mac-security-and-privacy-annotated.png">
-</p>
+![Mac Security and Privacy](/images/install/mac-security-and-privacy-annotated.png)
 
 ### Linux
 
@@ -61,9 +51,7 @@ Visit the [Connection Settings](connection-settings.md) menu for more connection
 
 The Blue Robotics Ping Echosounder is a 1-dimensional sonar that measures the distance to objects underwater. The device emits a brief 115 kHz acoustic pulse from the transducer at the face of the device. The device then measures the strength of returned acoustic energy and the amount of time for the returned energy to reach a significant level. The sound wave travels through water, and reflects or 'echos' off of solid objects, and travels back to the device. The device then calculates the distance to the solid object with the equation `distance = known speed of sound in water * (measured time for echo to return / 2)`.
 
-<p align="center">
-    <img src="images/echo.png">
-</p>
+![Echo](/images/echo.png)
 
 See the Wikipedia articles on [Echo sounding](https://en.wikipedia.org/wiki/Echo_sounding) and [Fishfinders](https://en.wikipedia.org/wiki/Fishfinder) for more information on how the device operates.
 
@@ -84,15 +72,11 @@ The Ping Viewer window consists of four important components:
 3. [Return Plot](#return-plot)
 4. [Waterfall](#waterfall)
 
-<p align="center">
-    <img src="images/viewer/annotated/interface-annotated.png">
-</p>
+![Interface Annotated](/images/viewer/annotated/interface-annotated.png)
 
 #### Distance Readout
 
-<p align="center">
-    <img src="images/viewer/distance-readout-closeup.png">
-</p>
+![Distance Readout](/images/viewer/distance-readout-closeup.png)
 
 The Distance Readout displays the distance to the target in the most recent measurement. This is the distance to the seafloor in [depth sounding](https://en.wikipedia.org/wiki/Depth_sounding) applications.
 
@@ -102,9 +86,7 @@ The size of the distance readout can be [moved and adjusted](hotkeys-and-shortcu
 
 #### Distance Axis
 
-<p align="center">
-    <img src="images/viewer/distance-axis-closeup.png">
-</p>
+![Distance Axis](/images/viewer/distance-axis-closeup.png)
 
 The Distance Axis is labeled with bold numbers on the right-hand edge of the Waterfall. This axis represents the distance from the Ping device transducer. The axis runs vertically down the screen, with the face of the transducer (zero distance) located at the top of the window. The deeper/farther an object is from the transducer, the closer its return will appear to the bottom of the window. The Distance Axis scale automatically adjusts to display the current scanning range of the Ping device.
 
@@ -112,9 +94,7 @@ There is an orange arrow on the Distance Axis indicating the distance to the tar
 
 #### Return Plot
 
-<p align="center">
-    <img src="images/viewer/return-plot-closeup.png">
-</p>
+![Return Plot](/images/viewer/return-plot-closeup.png)
 
 The Return Plot displays the return strength vs distance of the most recent [**Profile**](#distance-and-profile-measurements) sample. The plot displays the measurement of only a single dependent variable (return strength), and is simply mirrored for ease of viewing. Stronger returns appear as wider traces.
 
@@ -122,9 +102,7 @@ The Return Plot displays the return strength vs distance of the most recent [**P
 
 #### Waterfall
 
-<p align="center">
-    <img src="images/viewer/waterfall-closeup.png">
-</p>
+![Waterfall](/images/viewer/waterfall-closeup.png)
 
 The Waterfall is a three dimensional plot that occupies the main portion of the application window. The Waterfall plots consecutive [**Profile**](#distance-and-profile-measurements) samples (distance running vertically and color indicating signal strength). The horizontal axis is time; new data is displayed on the right edge of the Waterfall as older data moves to the left.
 

--- a/docs/notifications-and-updates.md
+++ b/docs/notifications-and-updates.md
@@ -1,6 +1,6 @@
 ## Notifications
 
-When notifications are available, you can display them by clicking on the bell icon in the bottom right hand corner of the Ping Viewer application window. To dismiss a single notification, click the ![](images/icons/close.png) icon on the notification. To dismiss all notifications, click the ![](images/icons/clear.png) icon at the bottom of the notification list.
+When notifications are available, you can display them by clicking on the bell icon in the bottom right hand corner of the Ping Viewer application window. To dismiss a single notification, click the <img src="/images/icons/close.png" style="display: inline;"/> icon on the notification. To dismiss all notifications, click the <img src="/images/icons/clear.png" style="display: inline;"/> icon at the bottom of the notification list.
 
 ## Application Updates
 

--- a/docs/replay-data.md
+++ b/docs/replay-data.md
@@ -1,6 +1,4 @@
-<p align="center">
-    <img src="../images/viewer/replay-data.png">
-</p>
+![Replay Data](/images/viewer/replay-data.png)
 
 The data from the Ping device is saved to a [log file](logging-and-user-files.md#sensor-logs). The data in these log files can be played back by the Ping Viewer application, and the result is that the data is displayed just the same as it was originally captured.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,3 +20,5 @@ nav:
         - Logging and User Files: logging-and-user-files.md
         - FAQ and Troubleshooting: faq-and-troubleshooting.md
         - Developers and OEMs: developers-and-oems.md
+extra_css:
+    - css/center_images.css


### PR DESCRIPTION
This adds a css rule to center all images in text, and replaces the html img tags with markdown where possible