### PR TITLE
Revert "ping: Move from empty message to general_request"

### DIFF
--- a/src/sensor/ping.cpp
+++ b/src/sensor/ping.cpp
@@ -491,8 +491,8 @@ void Ping::request(int id)
     }
     qCDebug(PING_PROTOCOL_PING) << "Requesting:" << id;
 
-    ping_msg_ping1D_general_request m;
-    m.set_requested_id(id);
+    ping_msg_ping1D_empty m;
+    m.set_id(id);
     m.updateChecksum();
     writeMessage(m);
 


### PR DESCRIPTION
The sensor in the actual version fail to provide profile messages with general_request
This is related to [#492](https://github.com/bluerobotics/ping-viewer/issues/492)

This reverts commit 00f13e9170979dacdf251457526d2a788b60fa9b.