### PR TITLE
Fix UDP usage with socat 

### DIFF
--- a/src/link/udplink.cpp
+++ b/src/link/udplink.cpp
@@ -13,11 +13,11 @@ UDPLink::UDPLink(QObject* parent)
     setType(LinkType::Udp);
 
     connect(_udpSocket, &QIODevice::readyRead, this, [this]() {
-        emit newData(_udpSocket->receiveDatagram().data());
+        emit newData(_udpSocket->readAll());
     });
 
     connect(this, &AbstractLink::sendData, this, [this](const QByteArray& data) {
-        _udpSocket->writeDatagram(data, _hostAddress, _port);
+        _udpSocket->write(data);
     });
 }
 
@@ -34,6 +34,28 @@ bool UDPLink::setConfiguration(const LinkConfiguration& linkConfiguration)
 
     _hostAddress = QHostAddress(linkConfiguration.args()->at(0));
     _port = linkConfiguration.args()->at(1).toInt();
+
+    // Check protocol detector comments and documentation about correct connect procedure
+    // TODO: Maybe UDPLink should provide a static function unify server connection/test
+
+    // Bind port
+    _udpSocket->bind(QHostAddress::Any, _port, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
+
+    // Connect with server
+    _udpSocket->connectToHost(_hostAddress, _port);
+
+    // Give the socket a second to connect to the other side otherwise error out
+    int socketAttemps = 0;
+    while(!_udpSocket->waitForConnected(100) && socketAttemps < 10 ) {
+        // Increases socketAttemps here to avoid empty loop optimization
+        socketAttemps++;
+    }
+    if(_udpSocket->state() != QUdpSocket::ConnectedState) {
+        qCWarning(PING_PROTOCOL_UDPLINK) << "Socket is not in connected state.";
+        QString errorMessage = QStringLiteral("Error (%1): %2.").arg(_udpSocket->state()).arg(_udpSocket->errorString());
+        qCWarning(PING_PROTOCOL_UDPLINK) << errorMessage;
+        return false;
+    }
 
     return true;
 }

--- a/src/sensor/protocoldetector.h
+++ b/src/sensor/protocoldetector.h
@@ -97,6 +97,25 @@ protected:
     bool canOpenPort(QSerialPortInfo& port, int msTimeout);
     bool checkBuffer(const QByteArray& buffer, LinkConfiguration& linkConf);
     bool checkSerial(LinkConfiguration& linkConf);
+
+    /**
+     * @brief Check if a device is provided by a UDP server
+     *  This functions follows IBM documentation about socket connections for clients
+     *  https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_71/rzab6/howdosockets.htm
+     *  https://www.ibm.com/support/knowledgecenter/en/SSB23S_1.1.0.14/gtpc1/gtpc1mst104.html
+     *      1. create socket
+     *      2. bind (optional, but necessary for QUdpSocket::ReuseAddressHint)
+     *      3. read/write
+     *      4. close
+     *
+     *  Without ReuseAddressHint, the next connection request will fail if there were connections open.
+     *
+     *  Since this uses the connectToHost method, all read and write functions should use the QIODevice primitive
+     *
+     * @param linkConf
+     * @return true
+     * @return false
+     */
     bool checkUdp(LinkConfiguration& linkConf);
     QVector<LinkConfiguration> updateLinkConfigurations(QVector<LinkConfiguration>& linkConfig) const;
 


### PR DESCRIPTION
@Williangalvani 	Please test with my remote raspberry.

This functions follows IBM documentation about socket connections for clients
https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_71/rzab6/howdosockets.htm
https://www.ibm.com/support/knowledgecenter/en/SSB23S_1.1.0.14/gtpc1/gtpc1mst104.html

  1. create socket
  2. bind (optional, but necessary for QUdpSocket::ReuseAddressHint)
  3. read/write
  4. close

Without `ReuseAddressHint`, the next connection request will fail if there were connections open.

Since this uses the `connectToHost` method, all read and write functions should use the `QIODevice` primitive.