### PR TITLE
ping360 scan speed optimizations

### DIFF
--- a/src/link/abstractlink.h
+++ b/src/link/abstractlink.h
@@ -212,9 +212,23 @@ public:
     void write(const char* data, int size)
     {
         if(size > 0) {
-            emit sendData(QByteArray(data, size));
-        };
+            if (_type == LinkType::Serial){
+                writeSync(data, size);
+            } else {
+                emit sendData(QByteArray(data, size));
+            }
+        }
     }
+
+    virtual void writeSync(const char* data, int size) { Q_UNUSED(data) Q_UNUSED(size) }
+
+    /**
+     * @brief Copy operation
+     *
+     * @param other
+     * @return const AbstractLink&
+     */
+    const AbstractLink& operator=(const AbstractLink& other);
 
     Q_PROPERTY(qint64 byteSize READ byteSize NOTIFY byteSizeChanged)
     Q_PROPERTY(LinkConfiguration* configuration READ configuration NOTIFY configurationChanged)

--- a/src/link/abstractlink.h.orig
+++ b/src/link/abstractlink.h.orig
@@ -212,7 +212,7 @@ public:
     void write(const char* data, int size)
     {
         if(size > 0) {
-            if (_type == LinkType::Serial) {
+            if (_type == LinkType::Serial){
                 writeSync(data, size);
             } else {
                 emit sendData(QByteArray(data, size));

--- a/src/link/seriallink.h
+++ b/src/link/seriallink.h
@@ -92,6 +92,11 @@ public:
      */
     void forceSensorAutomaticBaudRateDetection();
 
+    void writeSync(const char* data, int size) final override {
+        _port.write(data, size);
+        _port.flush();
+    }
+
 private:
     QSerialPort _port;
 };

--- a/src/link/seriallink.h.orig
+++ b/src/link/seriallink.h.orig
@@ -92,8 +92,7 @@ public:
      */
     void forceSensorAutomaticBaudRateDetection();
 
-    void writeSync(const char* data, int size) final override
-    {
+    void writeSync(const char* data, int size) final override {
         _port.write(data, size);
         _port.flush();
     }

--- a/src/sensor/ping360.cpp
+++ b/src/sensor/ping360.cpp
@@ -173,6 +173,11 @@ void Ping360::handleMessage(const ping_message& msg)
 
         _angle = deviceData.angle();
 
+        // request another transmission immediately
+        requestNextProfile();
+        // Restart timer
+        _timeoutProfileMessage.start();
+
         _data.resize(deviceData.data_length());
         for (int i = 0; i < deviceData.data_length(); i++) {
             _data.replace(i, deviceData.data()[i] / 255.0);
@@ -194,13 +199,6 @@ void Ping360::handleMessage(const ping_message& msg)
                 emit dataChanged();
             }
         }
-
-        // request another transmission
-        requestNextProfile();
-
-        // Restart timer
-        _timeoutProfileMessage.start();
-
         break;
     }
 

--- a/src/sensor/ping360.cpp
+++ b/src/sensor/ping360.cpp
@@ -146,11 +146,6 @@ void Ping360::handleMessage(const ping_message& msg)
 {
     qCDebug(PING_PROTOCOL_PING360) << "Handling Message:" << msg.message_id();
 
-    // Update frequency for each
-    messageFrequencies[msg.message_id()].setElapsed(_messageElapsedTimer.elapsed());
-    // Since we don't have a huge number of messages and this variable is pretty simple,
-    // we can use a single signal to update someone about the frequency update
-    emit messageFrequencyChanged();
 
     switch (msg.message_id()) {
 
@@ -236,6 +231,12 @@ void Ping360::handleMessage(const ping_message& msg)
         break;
     }
     emit parsedMsgsUpdate();
+
+    // Update frequency for each
+    messageFrequencies[msg.message_id()].setElapsed(_messageElapsedTimer.elapsed());
+    // Since we don't have a huge number of messages and this variable is pretty simple,
+    // we can use a single signal to update someone about the frequency update
+    emit messageFrequencyChanged();
 }
 
 void Ping360::firmwareUpdate(QString fileUrl, bool sendPingGotoBootloader, int baud, bool verify)

--- a/src/sensor/ping360.h
+++ b/src/sensor/ping360.h
@@ -543,7 +543,7 @@ private:
     int _angular_speed = 1;
     bool _autoTransmitDuration = true;
     uint _central_angle = 1;
-    bool _configuring = true;
+    bool _configuring = false;
     // Number of messages used to check the best baud rate
     int _preConfigurationTotalNumberOfMessages = 20;
     bool _reverse_direction = false;

--- a/src/sensor/pingsensor.cpp
+++ b/src/sensor/pingsensor.cpp
@@ -14,6 +14,21 @@ PingSensor::PingSensor()
     connect(dynamic_cast<PingParserExt*>(_parser), &PingParserExt::parseError, this, &PingSensor::parserErrorsUpdate);
 }
 
+void PingSensor::connectLink(const LinkConfiguration conConf, const LinkConfiguration& logConf)
+{
+    Sensor::connectLink(conConf, logConf);
+    if (_parser) {
+        connect(link(), &AbstractLink::newData, this, [this](QByteArray data) {
+            for (char b : data) {
+                Parser::ParserState result = _parser->parseByte(b);
+                if (result == Parser::NEW_MESSAGE) {
+                    handleMessage(_parser->rxMessage());
+                }
+            }
+        });
+        emit this->connectionUpdate();
+    }
+}
 
 void PingSensor::request(int id) const
 {

--- a/src/sensor/pingsensor.h
+++ b/src/sensor/pingsensor.h
@@ -35,6 +35,8 @@ public:
      */
     Q_INVOKABLE virtual void connectLink(AbstractLinkNamespace::LinkType connType, const QStringList& connString) = 0;
 
+    void connectLink(const LinkConfiguration conConf, const LinkConfiguration& logConf = LinkConfiguration()) override final;
+
     /**
      * @brief Get device source ID
      *

--- a/src/sensor/pingsensor.h.orig
+++ b/src/sensor/pingsensor.h.orig
@@ -35,8 +35,7 @@ public:
      */
     Q_INVOKABLE virtual void connectLink(AbstractLinkNamespace::LinkType connType, const QStringList& connString) = 0;
 
-    void connectLink(const LinkConfiguration conConf,
-                     const LinkConfiguration& logConf = LinkConfiguration()) override final;
+    void connectLink(const LinkConfiguration conConf, const LinkConfiguration& logConf = LinkConfiguration()) override final;
 
     /**
      * @brief Get device source ID

--- a/src/sensor/sensor.cpp
+++ b/src/sensor/sensor.cpp
@@ -55,9 +55,6 @@ void Sensor::connectLink(const LinkConfiguration conConf, const LinkConfiguratio
 
     emit linkUpdate();
 
-    if (_parser) {
-        connect(link(), &AbstractLink::newData, _parser, &Parser::parseBuffer);
-    }
 
     emit connectionOpen();
 

--- a/src/sensor/sensor.h
+++ b/src/sensor/sensor.h
@@ -53,7 +53,7 @@ public:
      * @param logConf log configuration
      *
      */
-    void connectLink(const LinkConfiguration conConf, const LinkConfiguration& logConf = LinkConfiguration());
+    virtual void connectLink(const LinkConfiguration conConf, const LinkConfiguration& logConf = LinkConfiguration());
 
     /**
      * @brief Add new log connection


### PR DESCRIPTION
This is based on #537.

This is the situation that we are dealing with regarding communication between the ping360 device hardware and the ping-viewer application:

![image](https://user-images.githubusercontent.com/8315108/62658988-34674100-b938-11e9-9c69-87ccf5891f4d.png)

This time period of 18 milliseconds is what I will term the `viewer-side latency`. The answer to the question 'is this viewer-side latency necessary?' is **no**! Ideally, it will be zero.

The sonar response with default settings is a constant 8ms. The maximum theoretical message frequency @2Mbaud in this case is 1/0.008 = 125Hz (viewer-side latency = 0). The maximum theoretical full scan speed is 400 / 125 = 3.2 seconds

In an attempt to reduce the signal->slot chain between ping-viewer rx -> ping-viewer tx, I did two primary things:

- removed use of newMessage signal from parser, and parse the buffer/handle the message synchronously
- added writeSync to write immediately when abstractlink::write is called

I also moved some calls around inside of `handleMessage` in order to request the next data message from the ping360 device as soon as possible.

**master communicating at default 2m range and 2Mbaud scans at 30 Hz**
**this patch communicating at default 2m range and 2Mbaud scans at 60 Hz**

There remains a ton of jitter from the async (maybe readyRead())?, sometimes the viewer-side latency is 20ms.

As a point of reference for what is technically possible, the minimal example [test-device-ping360.cpp](https://github.com/jaxxzer/ping-cpp/blob/test-device/test/test-device-ping360.cpp) has a full scan time of 3.6 seconds (110Hz) and the viewer-side latency is always less than 1ms.