### PR TITLE
Fix off by one

### DIFF
--- a/qml/Ping360ControlPanel.qml
+++ b/qml/Ping360ControlPanel.qml
@@ -36,7 +36,8 @@ Item {
             PingSlider {
                 Layout.fillWidth: true
                 text: "Range (m)"
-                value: ping.range
+                value: Math.round(ping.range)
+                control.stepSize: 1
                 control.from: 1
                 control.to: 100
                 control.onMoved: ping.range = control.value

--- a/src/sensor/ping360.h
+++ b/src/sensor/ping360.h
@@ -157,7 +157,7 @@ public:
     void set_range(uint newRange)
     {
         if(newRange != range()) {
-            _sample_period = 2*newRange/(_num_points*_speed_of_sound*_samplePeriodTickDuration);
+            _sample_period = ceil(2*newRange/(_num_points*_speed_of_sound*_samplePeriodTickDuration));
             emit rangeChanged();
         }
     }


### PR DESCRIPTION
The `round()` in the control panel is cosmetic only, to avoid broken (although real) numbers.
The math for range calculation generates numbers such as 22.98.

The float->int cast calculating `_sample_period` seemed to be falling shot of our range, so we can round up instead.

fix #572