### PR TITLE
PingSlider: Value precision should not be defined by slider

### DIFF
--- a/qml/PingSlider.qml
+++ b/qml/PingSlider.qml
@@ -28,6 +28,6 @@ RowLayout {
         Layout.fillWidth: true
 
         Layout.preferredWidth: 40
-        text: root.value.toFixed(2)
+        text: root.value
     }
 }


### PR DESCRIPTION
Also, right now all inputs are defined in integer steps. 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>