### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = false
+indent_style = space
+max_line_length = 120
+charset = utf-8
+
+[*.{cpp,hpp,c,h}]
+indent_width = 4
+
+[*.qml]
+indent_width = 4
+


### PR DESCRIPTION
EditorConfig is a special file that's handled by many editors and
can keep the configuration of the specifics of the project out of
the editor settings. This is really userfull if you work in more
than one project at a time, like we do.

KDevelop, Qt Creator, Vim, Emacs, Visual Studio Code, all have
native or plugin support for editorconfig.