### PR TITLE
protocoldetector: scan for high baudrates, drop 9600 for now

### DIFF
--- a/src/sensor/protocoldetector.cpp
+++ b/src/sensor/protocoldetector.cpp
@@ -100,9 +100,9 @@ QVector<LinkConfiguration> ProtocolDetector::updateLinkConfigurations(QVector<Li
         }
 
         // Add valid port and baudrate
-        // Ping360 can't handle 9600 requests with 115200 request in a sort time priod
+        // Ping360 can't handle 9600 requests with 2000000 request in a short time priod, look for bug in firmware
         // TODO: Fix Ping360 is not possible, we should drop 9600 checks if 115200 returns fine
-        for(auto baud : {115200, 9600}) {
+        for(auto baud : {2000000, 1000000, 921600, 460800, 230400, 115200, /*9600*/}) {
             auto config = {portInfo.portName(), QString::number(baud)};
             tempConfigs.append({LinkType::Serial, config, QString("Detector serial link")});
         }


### PR DESCRIPTION
This allows connecting to ping360 at 2M. There is some problem with the firmware in moving from 9600 to 2M baudrate or something, some combinations work, some do not. We need to investigate the exact problem more.

I think we will be able to work it out to add 9600 back in the future. Otherwise, it should be possible to connect a ping1d@9600 with manual connection.

fix #558 