### PR TITLE
Ping360: Do automatic baud rate detection

### DIFF
--- a/qml/ConnectionMenu.qml
+++ b/qml/ConnectionMenu.qml
@@ -149,6 +149,7 @@ Item {
 
                 ComboBox {
                     id: baudrateBox
+                    visible: deviceCB.model.get(deviceCB.currentIndex).deviceId == PingEnumNamespace.PingDeviceType.PING1D
                     model: [115200, 9600]
                 }
             }

--- a/qml/Ping360ControlPanel.qml
+++ b/qml/Ping360ControlPanel.qml
@@ -122,6 +122,21 @@ GroupBox {
                 control.to: 359
                 control.onMoved: ping.angle_offset = control.value
             }
+            RowLayout {
+                Button {
+                    id: autoBaudRateChB
+                    text: "Auto baudrate"
+                    onClicked: ping.startConfiguration()
+                }
+                PingComboBox {
+                    model: ping.validBaudRates
+                    Layout.fillWidth: true
+                    enabled: !autoBaudRateChB.checked
+                    onCurrentTextChanged: {
+                        ping.setBaudRateAndRequestProfile(parseInt(currentText))
+                    }
+                }
+            }
         }
     }
 }

--- a/qml/Ping360Status.qml
+++ b/qml/Ping360Status.qml
@@ -26,7 +26,7 @@ Item {
                 model: [
                     "FW: " + ping.firmware_version_major + "." + ping.firmware_version_minor + "." + ping.firmware_version_patch,
                     "SRC: " + ping.srcId + " DST: " + ping.dstId,
-                    "Connection: " + ping.link.configuration.createConfString(),
+                    "Connection: " + ping.link.configuration.string,
                     "Range (m): " + ping.range.toFixed(2),
                     "Sample period (μs): " + ping.sample_period,
                     "Number of samples (#): " + ping.number_of_points,

--- a/qml/PingStatus.qml
+++ b/qml/PingStatus.qml
@@ -26,7 +26,7 @@ Item {
                 model: [
                     "FW: " + ping.firmware_version_major + "." + ping.firmware_version_minor,
                     "SRC: " + ping.srcId + " DST: " + ping.dstId,
-                    "Connection: " + ping.link.configuration.createConfString(),
+                    "Connection: " + ping.link.configuration.string,
                     "Distance (mm): " + ping.distance,
                     "Auto (bool): " + ping.mode_auto,
                     "Scan Start (mm): " + ping.start_mm,

--- a/src/devicemanager/devicemanager.cpp
+++ b/src/devicemanager/devicemanager.cpp
@@ -71,6 +71,9 @@ void DeviceManager::stopDetecting()
 
 void DeviceManager::connectLink(LinkConfiguration* linkConf)
 {
+    // Stop detector if we are going to connect with something
+    stopDetecting();
+
     // Find configuration in vector with valid index
     int objIndex = -1;
     for(int i{0}; i < _sensors[Connection].size(); i++) {

--- a/src/link/abstractlink.h
+++ b/src/link/abstractlink.h
@@ -217,7 +217,7 @@ public:
     }
 
     Q_PROPERTY(qint64 byteSize READ byteSize NOTIFY byteSizeChanged)
-    Q_PROPERTY(LinkConfiguration* configuration READ configuration CONSTANT)
+    Q_PROPERTY(LinkConfiguration* configuration READ configuration NOTIFY configurationChanged)
     Q_PROPERTY(QTime elapsedTime READ elapsedTime NOTIFY elapsedTimeChanged)
     Q_PROPERTY(QString elapsedTimeString READ elapsedTimeString NOTIFY elapsedTimeChanged)
     Q_PROPERTY(bool isAutoConnect READ isAutoConnect WRITE setAutoConnect NOTIFY autoConnectChanged)
@@ -231,6 +231,7 @@ public:
 
 signals:
     void availableConnectionsChanged();
+    void configurationChanged();
     void nameChanged(const QString& name);
     void autoConnectChanged();
     void linkChanged(AbstractLinkNamespace::LinkType link);

--- a/src/link/linkconfiguration.cpp
+++ b/src/link/linkconfiguration.cpp
@@ -77,6 +77,12 @@ LinkConfiguration::Error LinkConfiguration::error() const
     return NoErrors;
 }
 
+void LinkConfiguration::setArgs(const QStringList& args)
+{
+    _linkConf.args = args;
+    emit configurationChanged();
+}
+
 QString LinkConfiguration::serialPort()
 {
     if(!checkType(LinkType::Serial) || !_linkConf.args.size()) {
@@ -159,5 +165,6 @@ QDataStream& operator>>(QDataStream &in, LinkConfiguration &linkConfiguration)
                             name,
                             static_cast<PingDeviceType>(variantDeviceType.toInt())
                         );
+    emit linkConfiguration.configurationChanged();
     return in;
 }

--- a/src/link/linkconfiguration.h
+++ b/src/link/linkconfiguration.h
@@ -100,6 +100,13 @@ public:
     Q_INVOKABLE QStringList argsAsConst() const { return _linkConf.args; };
 
     /**
+     * @brief Set link configuration arguments
+     *
+     * @param args
+     */
+    void setArgs(const QStringList& args);
+
+    /**
      * @brief Return PingDeviceType enumartion for device specific identification
      *
      * @return PingDeviceType
@@ -285,6 +292,11 @@ public:
         this->_linkConf = other.configurationStruct();
         return *this;
     }
+
+    Q_PROPERTY(QString string READ createFullConfString NOTIFY configurationChanged)
+
+signals:
+    void configurationChanged();
 
 private:
     static const QMap<Error, QString> _errorMap;

--- a/src/link/seriallink.cpp
+++ b/src/link/seriallink.cpp
@@ -73,7 +73,7 @@ bool SerialLink::startConnection()
     QThread::usleep(500);
     _port.setBreakEnabled(false);
     QThread::msleep(11);
-    _port.write("U");
+    _port.write("UUU");
     _port.flush();
     QThread::msleep(11);
 

--- a/src/link/seriallink.cpp
+++ b/src/link/seriallink.cpp
@@ -64,18 +64,7 @@ bool SerialLink::startConnection()
         return false;
     }
 
-    /** ABR fluxogram
-     * 1. Use break to force a 0 logical state for an entire frame
-     * 2. Send U (0b01010101) to allow an automatic baud rate detection
-     * 3. Force a write condition in the serial using the `flush` command
-     */
-    _port.setBreakEnabled(true);
-    QThread::usleep(500);
-    _port.setBreakEnabled(false);
-    QThread::msleep(11);
-    _port.write("UUU");
-    _port.flush();
-    QThread::msleep(11);
+    forceSensorAutomaticBaudRateDetection();
 
     return true;
 }
@@ -102,6 +91,31 @@ QStringList SerialLink::listAvailableConnections()
         emit availableConnectionsChanged();
     }
     return list;
+}
+
+void SerialLink::setBaudRate(int baudRate)
+{
+    _port.setBaudRate(baudRate);
+    QStringList args = _linkConfiguration.argsAsConst();
+    args[1] = QString::number(baudRate);
+    _linkConfiguration.setArgs(args);
+    forceSensorAutomaticBaudRateDetection();
+}
+
+void SerialLink::forceSensorAutomaticBaudRateDetection()
+{
+    /** ABR fluxogram
+     * 1. Use break to force a 0 logical state for an entire frame
+     * 2. Send U (0b01010101) to allow an automatic baud rate detection
+     * 3. Force a write condition in the serial using the `flush` command
+     */
+    _port.setBreakEnabled(true);
+    QThread::usleep(500);
+    _port.setBreakEnabled(false);
+    QThread::msleep(11);
+    _port.write("UUU");
+    _port.flush();
+    QThread::msleep(11);
 }
 
 SerialLink::~SerialLink()

--- a/src/link/seriallink.cpp
+++ b/src/link/seriallink.cpp
@@ -47,6 +47,7 @@ bool SerialLink::setConfiguration(const LinkConfiguration& linkConfiguration)
 
     _port.setPortName(linkConfiguration.args()->at(0));
     _port.setBaudRate(linkConfiguration.args()->at(1).toInt());
+    emit configurationChanged();
     return true;
 }
 

--- a/src/link/seriallink.h
+++ b/src/link/seriallink.h
@@ -79,6 +79,19 @@ public:
      */
     bool startConnection() final override;
 
+    /**
+     * @brief Set a valid baudrate
+     *
+     * @param baudRate
+     */
+    void setBaudRate(int baudRate);
+
+    /**
+     * @brief Force sensor to do automatic baud rate detection
+     *
+     */
+    void forceSensorAutomaticBaudRateDetection();
+
 private:
     QSerialPort _port;
 };

--- a/src/link/seriallink.h
+++ b/src/link/seriallink.h
@@ -56,10 +56,11 @@ public:
 
     /**
      * @brief Return a list of available ports
+     * Any change in the port should be notified and dealed via `configurationChanged()`
      *
      * @return QSerialPort*
      */
-    QSerialPort* port() { return &_port; };
+    const QSerialPort* port() const { return &_port; };
 
     /**
      * @brief Set link configuration

--- a/src/sensor/ping.cpp
+++ b/src/sensor/ping.cpp
@@ -365,7 +365,8 @@ void Ping::flash(const QString& fileUrl, bool sendPingGotoBootloader, int baud, 
     // Wait for bytes to be written before finishing the connection
     while (serialLink->port()->bytesToWrite()) {
         qCDebug(PING_PROTOCOL_PING) << "Waiting for bytes to be written...";
-        serialLink->port()->waitForBytesWritten();
+        // We are not changing the connection structure, only waiting for bytes to be written
+        const_cast<QSerialPort*>(serialLink->port())->waitForBytesWritten();
         qCDebug(PING_PROTOCOL_PING) << "Done !";
     }
 

--- a/src/sensor/protocoldetector.cpp
+++ b/src/sensor/protocoldetector.cpp
@@ -134,12 +134,13 @@ bool ProtocolDetector::checkSerial(LinkConfiguration& linkConf)
         return false;
     }
     qCDebug(PING_PROTOCOL_PROTOCOLDETECTOR) << "Port is open";
+
     port.setBaudRate(baudrate);
     port.setBreakEnabled(true);
     QThread::usleep(500);
     port.setBreakEnabled(false);
     QThread::msleep(11);
-    port.write("U");
+    port.write("UUU");
     port.flush();
     QThread::msleep(11);
 


### PR DESCRIPTION
Replace https://github.com/bluerobotics/ping-viewer/pull/606

This PR replaces #606 using the automatic baud rate detection, also allows the user to select the best baud rate manually if necessary and to enable the automatic baud rate detection procedure again. 

1. Detects device via normal baud rates 
2. After user selection it checks for the possible baud rates and request N messages to make sure that everything is fine with this baud rate.
3. Select the desired baud rate and start profile requests

This also adds a check box and baud rate selection list for the user to select the desired baud rate. 


![deepin-screen-recorder_pingviewer_20190729122008](https://user-images.githubusercontent.com/1215497/62060357-5b689900-b1fb-11e9-9bcc-b7678065dc6e.gif)

note: I'm using 5M and 3M to test not working baud rates