### PR TITLE
seriallink: Check if port is open before opening

### DIFF
--- a/src/link/seriallink.cpp
+++ b/src/link/seriallink.cpp
@@ -52,6 +52,12 @@ bool SerialLink::setConfiguration(const LinkConfiguration& linkConfiguration)
 
 bool SerialLink::startConnection()
 {
+    // Check if port was already open
+    if(isOpen()) {
+        qCDebug(PING_PROTOCOL_SERIALLINK) << "Serial port will be restarted.";
+        finishConnection();
+    }
+
     if(!_port.open(QIODevice::ReadWrite)) {
         qCWarning(PING_PROTOCOL_SERIALLINK) << "Fail to open serial port:" << _port.error();
         return false;


### PR DESCRIPTION
Fix error message if the port is already open
Also allows the connection to be redone if baud rate changes occur

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>