### PR TITLE
devicemanager: Do not wait for thread to finish

### DIFF
--- a/src/devicemanager/devicemanager.cpp
+++ b/src/devicemanager/devicemanager.cpp
@@ -69,7 +69,6 @@ void DeviceManager::stopDetecting()
     qCDebug(DEVICEMANAGER) << "Stop protocol detector service.";
     _detector->stop();
     _detectorThread.quit();
-    _detectorThread.wait();
 }
 
 void DeviceManager::connectLink(LinkConfiguration* linkConf)
@@ -153,4 +152,5 @@ DeviceManager* DeviceManager::self()
 DeviceManager::~DeviceManager()
 {
     stopDetecting();
+    _detectorThread.wait();
 }


### PR DESCRIPTION
Fix [#577](https://github.com/bluerobotics/ping-viewer/issues/577)

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>