### PR TITLE
abstractlink: remove unused operator equals

### DIFF
--- a/src/link/abstractlink.cpp
+++ b/src/link/abstractlink.cpp
@@ -11,12 +11,4 @@ AbstractLink::AbstractLink(QObject* parent)
 {
 }
 
-const AbstractLink& AbstractLink::operator=(const AbstractLink& other)
-{
-    _autoConnect = other._autoConnect;
-    _type = other._type;
-    _name = other._name;
-    return *this;
-}
-
 AbstractLink::~AbstractLink() = default;

--- a/src/link/abstractlink.h
+++ b/src/link/abstractlink.h
@@ -216,14 +216,6 @@ public:
         };
     }
 
-    /**
-     * @brief Copy operation
-     *
-     * @param other
-     * @return const AbstractLink&
-     */
-    const AbstractLink& operator=(const AbstractLink& other);
-
     Q_PROPERTY(qint64 byteSize READ byteSize NOTIFY byteSizeChanged)
     Q_PROPERTY(LinkConfiguration* configuration READ configuration CONSTANT)
     Q_PROPERTY(QTime elapsedTime READ elapsedTime NOTIFY elapsedTimeChanged)


### PR DESCRIPTION
Operator equals in a class that's supposed to be abstract is a code
smell, usually you want to copy the combination of the super class and
child class.

Code still compiles, that means that either the operator= is not used
or that the compiler implemented a correct operator=.