### PR TITLE
appveyor: Use always the last Qt version available of 5.12 from appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ environment:
   matrix:
     - MSVC_VERSION: 17
       RUNTIME_LINKAGE: static
-      QT_VERSION: 5.12.2
+      QT_VERSION: 5.12
       QT_LINKAGE: static
       COVERITY_BUILD_CANDIDATE: True
       QTDIR: C:\Qt\%QT_VERSION%\msvc2017_64


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>