### PR TITLE
ping360: Fix initial angle for better visualization and better response time

### DIFF
--- a/src/sensor/ping360.h
+++ b/src/sensor/ping360.h
@@ -429,7 +429,7 @@ private:
     static const uint16_t _viewerDefaultTransmitFrequency = 750;
     static const uint16_t _viewerDefaultNumberOfSamples = _firmwareMaxNumberOfPoints;
 
-    uint16_t _angle = _firmwareDefaultAngle;
+    uint16_t _angle = 200;
     uint16_t _transmit_duration = _firmwareDefaultTransmitDuration;
     uint32_t _gain_setting = _firmwareDefaultGainSetting;
     uint16_t _num_points = _viewerDefaultNumberOfSamples;


### PR DESCRIPTION
The sensor 0 is in the back of the product, we should start the
scan from the product case `0 position`, that is the 200 of the sensor.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>