### PR TITLE
Move debug overlays to lower left corner

### DIFF
--- a/qml/Ping360Status.qml
+++ b/qml/Ping360Status.qml
@@ -10,7 +10,8 @@ Item {
     property var ping: null
 
     Rectangle {
-        anchors.centerIn: parent
+        anchors.left: parent.left
+        anchors.bottom: parent.bottom
 
         color: "black"
         opacity: 0.75

--- a/qml/PingStatus.qml
+++ b/qml/PingStatus.qml
@@ -10,7 +10,8 @@ Item {
     property var ping: null
 
     Rectangle {
-        anchors.centerIn: parent
+        anchors.left: parent.left
+        anchors.bottom: parent.bottom
 
         color: "black"
         opacity: 0.75


### PR DESCRIPTION
The debug window on top of the plot is really annoying. this moves it to the lower left corner:
![Screenshot from 2019-08-02 14-50-14](https://user-images.githubusercontent.com/4013804/62388981-09927c80-b535-11e9-87f2-a51e4e6d2fca.png)

![Screenshot from 2019-08-02 14-54-16](https://user-images.githubusercontent.com/4013804/62389161-6f7f0400-b535-11e9-8f44-401c2a33f739.png)

