### PR TITLE
Improved speed: Updates over #540

### DIFF
--- a/src/link/seriallink.cpp
+++ b/src/link/seriallink.cpp
@@ -19,6 +19,7 @@ SerialLink::SerialLink(QObject* parent)
 
     connect(this, &AbstractLink::sendData, this, [this](const QByteArray& data) {
         _port.write(data);
+        _port.flush();
     });
 
     connect(&_port, &QSerialPort::errorOccurred, this, [this](QSerialPort::SerialPortError error) {

--- a/src/link/seriallink.cpp
+++ b/src/link/seriallink.cpp
@@ -96,7 +96,9 @@ QStringList SerialLink::listAvailableConnections()
 
 void SerialLink::setBaudRate(int baudRate)
 {
+    _port.close();
     _port.setBaudRate(baudRate);
+    startConnection();
     QStringList args = _linkConfiguration.argsAsConst();
     args[1] = QString::number(baudRate);
     _linkConfiguration.setArgs(args);

--- a/src/link/seriallink.cpp
+++ b/src/link/seriallink.cpp
@@ -20,7 +20,7 @@ SerialLink::SerialLink(QObject* parent)
     connect(this, &AbstractLink::sendData, this, [this](const QByteArray& data) {
         _port.write(data);
         _port.flush();
-    });
+    }, Qt::DirectConnection);
 
     connect(&_port, &QSerialPort::errorOccurred, this, [this](QSerialPort::SerialPortError error) {
         switch(error) {

--- a/src/sensor/ping360.cpp
+++ b/src/sensor/ping360.cpp
@@ -320,7 +320,6 @@ void Ping360::setBaudRate(int baudRate)
 
     qCDebug(PING_PROTOCOL_PING360) << "Moving to baud rate:" << baudRate;
     serialLink->setBaudRate(baudRate);
-    link()->startConnection();
     emit linkUpdate();
 }
 

--- a/src/sensor/ping360.cpp
+++ b/src/sensor/ping360.cpp
@@ -163,13 +163,12 @@ void Ping360::handleMessage(const ping_message& msg)
         if(_configuring) {
             _baudrateConfigurationTimer.start();
             checkBaudrateProcess();
-            return;
         } else {
             _baudrateConfigurationTimer.stop();
             _timeoutProfileMessage.start();
             requestNextProfile();
-            return;
         }
+        return;
     }
 
     case Ping360Id::DEVICE_DATA: {

--- a/src/sensor/ping360.cpp
+++ b/src/sensor/ping360.cpp
@@ -151,12 +151,6 @@ void Ping360::handleMessage(const ping_message& msg)
 {
     qCDebug(PING_PROTOCOL_PING360) << "Handling Message:" << msg.message_id();
 
-    // Update frequency for each
-    messageFrequencies[msg.message_id()].setElapsed(_messageElapsedTimer.elapsed());
-    // Since we don't have a huge number of messages and this variable is pretty simple,
-    // we can use a single signal to update someone about the frequency update
-    emit messageFrequencyChanged();
-
     switch (msg.message_id()) {
 
     case CommonId::DEVICE_INFORMATION: {
@@ -241,6 +235,13 @@ void Ping360::handleMessage(const ping_message& msg)
         qWarning(PING_PROTOCOL_PING360) << "UNHANDLED MESSAGE ID:" << msg.message_id();
         break;
     }
+
+    // Update frequency for each
+    messageFrequencies[msg.message_id()].setElapsed(_messageElapsedTimer.elapsed());
+    // Since we don't have a huge number of messages and this variable is pretty simple,
+    // we can use a single signal to update someone about the frequency update
+    emit messageFrequencyChanged();
+
     emit parsedMsgsUpdate();
 }
 

--- a/src/sensor/ping360.cpp
+++ b/src/sensor/ping360.cpp
@@ -87,6 +87,10 @@ void Ping360::checkBaudrateProcess()
 
     static int count = _ABRTotalNumberOfMessages;
 
+    if(_resetBaudRateDetection) {
+        count = _ABRTotalNumberOfMessages;
+    }
+
     // We are starting to check the new baud rate
     if(count == _ABRTotalNumberOfMessages) {
         detectBaudrates();
@@ -341,6 +345,14 @@ void Ping360::detectBaudrates()
     // last parser error count
     static int lastParserErrorCount = 0;
     static int lastParserMsgsCount = 0;
+
+    if(_resetBaudRateDetection) {
+        _resetBaudRateDetection = false;
+        index = 0;
+        baudRateToError.clear();
+        lastParserErrorCount = 0;
+        lastParserMsgsCount = 0;
+    };
 
     // Check error margin
     int lastCounter = -1;

--- a/src/sensor/ping360.cpp
+++ b/src/sensor/ping360.cpp
@@ -169,7 +169,15 @@ void Ping360::handleMessage(const ping_message& msg)
         // Parse message
         const ping360_device_data deviceData(msg);
 
+        // Get angle to request next message
         _angle = deviceData.angle();
+
+        // Request next message ASAP
+        // request another transmission
+        requestNextProfile();
+
+        // Restart timer
+        _timeoutProfileMessage.start();
 
         _data.resize(deviceData.data_length());
         for (int i = 0; i < deviceData.data_length(); i++) {
@@ -192,12 +200,6 @@ void Ping360::handleMessage(const ping_message& msg)
                 emit dataChanged();
             }
         }
-
-        // request another transmission
-        requestNextProfile();
-
-        // Restart timer
-        _timeoutProfileMessage.start();
 
         break;
     }

--- a/src/sensor/ping360.h
+++ b/src/sensor/ping360.h
@@ -464,7 +464,7 @@ public:
         if(_timeoutProfileMessage.isActive()) {
             _timeoutProfileMessage.stop();
         }
-        startPreConfigurationProcess();
+        checkBaudrateProcess();
     }
 
     /**

--- a/src/sensor/ping360.h
+++ b/src/sensor/ping360.h
@@ -464,6 +464,7 @@ public:
         if(_timeoutProfileMessage.isActive()) {
             _timeoutProfileMessage.stop();
         }
+        _resetBaudRateDetection = true;
         checkBaudrateProcess();
     }
 
@@ -571,6 +572,7 @@ private:
      *  Without this timer, we are going to wait forever for a reply without asking again.
      */
     QTimer _baudrateConfigurationTimer;
+    bool _resetBaudRateDetection = true;
 
     // Helper structure to hold frequency information for each message
     struct MessageFrequencyHelper {

--- a/src/sensor/pingsensor.cpp
+++ b/src/sensor/pingsensor.cpp
@@ -10,7 +10,8 @@ PingSensor::PingSensor()
     ,_lostMessages(0)
 {
     _parser = new PingParserExt();
-    connect(dynamic_cast<PingParserExt*>(_parser), &PingParserExt::newMessage, this, &PingSensor::handleMessagePrivate);
+    connect(dynamic_cast<PingParserExt*>(_parser), &PingParserExt::newMessage, this, &PingSensor::handleMessagePrivate,
+            Qt::DirectConnection);
     connect(dynamic_cast<PingParserExt*>(_parser), &PingParserExt::parseError, this, &PingSensor::parserErrorsUpdate);
 }
 

--- a/src/sensor/sensor.cpp
+++ b/src/sensor/sensor.cpp
@@ -56,7 +56,7 @@ void Sensor::connectLink(const LinkConfiguration conConf, const LinkConfiguratio
     emit linkUpdate();
 
     if (_parser) {
-        connect(link(), &AbstractLink::newData, _parser, &Parser::parseBuffer);
+        connect(link(), &AbstractLink::newData, _parser, &Parser::parseBuffer, Qt::DirectConnection);
     }
 
     emit connectionOpen();


### PR DESCRIPTION
- Small improvements over #540 
- Corrections/Quality of life in ABR

I can break this in two PRs, but it's easier to test the speed improvements with the ABR improvements. 

This PR should hit something near 60~50Hz with the timer latency configured.
Linux: `sudo echo 1 > /sys/bus/usb-serial/devices/ttyUSB0/latency_timer`
Windows: **Device Manager** → Com port → **Properties** → **Advanced** → Latency Timer: 1

It takes 8s  to do a full spin in a 2m range and 2M baud rate.
> Note: Message frequency is not the same thing as full scan time. Messages in the same position will be faster and with more messages but with slow scan time. We should add scan time in the sensor status. 