### PR TITLE
DeviceManagerViewer: Use background color in place of tooltip for user feedback

### DIFF
--- a/qml/DeviceManagerViewer.qml
+++ b/qml/DeviceManagerViewer.qml
@@ -130,12 +130,11 @@ PingPopup {
                 Layout.fillHeight: true
                 clip: true
                 model: DeviceManager
-                spacing: 4
                 delegate: Rectangle {
                     id: rectDelegate
                     height: 40
                     width: parent.width
-                    color: "transparent"
+                    color: buttonMouseArea.containsMouse ? 'gainsboro' : 'transparent'
                     Rectangle {
                        height: 1
                        color: 'gray'
@@ -156,12 +155,6 @@ PingPopup {
                             // We should check if Sensor device is created and if it's really connected and
                             // communicating with the device
                             root.close()
-                        }
-                        ToolTip {
-                            x: parent.mouseX
-                            y: parent.mouseY - height - 5
-                            visible: parent.containsMouse
-                            text: "Connect."
                         }
                     }
 


### PR DESCRIPTION
Fix [#609](https://github.com/bluerobotics/ping-viewer/issues/609)

![deepin-screen-recorder_Select area_20190809140055](https://user-images.githubusercontent.com/1215497/62796027-79ad7f00-baae-11e9-94b8-35b701e4b975.gif)

The color appears weird in the gif..
But here is ok:
![image](https://user-images.githubusercontent.com/1215497/62796048-8af68b80-baae-11e9-9c14-85af32c1e15e.png)


Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>