### PR TITLE
protocoldetector: Add timeout in wait for bytes

### DIFF
--- a/src/sensor/protocoldetector.cpp
+++ b/src/sensor/protocoldetector.cpp
@@ -147,7 +147,7 @@ bool ProtocolDetector::checkSerial(LinkConfiguration& linkConf)
 
     // Probe
     port.write(_deviceInformationMessageByteArray);
-    port.waitForBytesWritten();
+    port.waitForBytesWritten(100);
 
     int attempts = 0;
 


### PR DESCRIPTION
Validated by Brian: `The Bluetooth test found the ping360 in 0:07`

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>