### PR TITLE
Cmake port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,56 @@
+project(ping-viewer)
+cmake_minimum_required(VERSION 3.8)
+
+find_package(ECM 5.54.0 REQUIRED NO_MODULE)
+set(CMAKE_CXX_STANDARD 17)
+set(CXX_STANDARD_REQUIRED ON)
+
+set(QT_MIN_VERSION "5.12.0")
+
+set(CMAKE_AUTOMOC ON)
+set(AUTOMOC_MOC_OPTIONS -Muri=org.bluerobotics.pingviewer)
+
+set(CMAKE_AUTORCC ON)
+
+add_definitions(
+  -DQT_USE_QSTRINGBUILDER
+  -DQT_NO_CAST_TO_ASCII
+  -DQT_STRICT_ITERATORS
+  -DQT_NO_CAST_FROM_BYTEARRAY
+  -DQT_USE_FAST_OPERATOR_PLUS
+)
+
+# Set the Git variables here.
+if(TRUE)
+  set(GIT_VERSION "fake_version_fixme_later")
+  set(GIT_VERSION_DATE "fake_version_date_fixme_later")
+  set(GIT_TAG "fake_git_tag")
+  set(GIT_URL "fake_git_url")
+
+  add_definitions(-DGIT_VERSION="${GIT_VERSION}")
+  add_definitions(-DGIT_VERSION_DATE="${GIT_VERSION_DATE}")
+  add_definitions(-DGIT_TAG="${GIT_TAG}")
+  add_definitions(-DGIT_URL="${GIT_URL}")
+endif()
+
+find_package(Qt5 ${QT_MIN_VERSION} REQUIRED NO_MODULE COMPONENTS
+    Charts
+    Concurrent
+    Core
+    Gamepad
+    Network
+    Positioning
+    Qml
+    Quick
+    QuickControls2
+    SerialPort
+    Widgets
+)
+
+# global include directories
+include_directories(
+    lib/ping-cpp/ping-cpp/src/message/
+    lib/maddy/maddy/include/
+)
+
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,44 @@
+include_directories(.)
+
+add_subdirectory(devicemanager)
+add_subdirectory(filemanager)
+add_subdirectory(flash)
+add_subdirectory(link)
+add_subdirectory(logger)
+add_subdirectory(network)
+add_subdirectory(notification)
+add_subdirectory(qtquickcomponents)
+add_subdirectory(sensor)
+add_subdirectory(settings)
+add_subdirectory(style)
+add_subdirectory(util)
+add_subdirectory(waterfall)
+
+add_executable(ping-viewer
+    main.cpp
+    ../resources.qrc
+    ../lib/ping-cpp/ping-cpp/src/message/ping-message-all.h
+)
+
+target_link_libraries(
+    ping-viewer
+    Qt5::Core
+    Qt5::Qml
+    Qt5::Quick
+    Qt5::QuickControls2
+    Qt5::Charts
+    Qt5::Widgets # QApplication
+    devicemanager
+    filemanager
+    flash
+    link
+    logger
+    network
+    notification
+    qtquickcomponents
+    sensor
+    settings
+    style
+    util
+    waterfall
+)

--- a/src/devicemanager/CMakeLists.txt
+++ b/src/devicemanager/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(
+    devicemanager
+STATIC
+    devicemanager.cpp
+)
+
+target_link_libraries(devicemanager
+PRIVATE
+    Qt5::Core
+    Qt5::Network
+    Qt5::Qml
+    Qt5::Quick
+)

--- a/src/devicemanager/devicemanager.cpp
+++ b/src/devicemanager/devicemanager.cpp
@@ -1,8 +1,8 @@
 #include "devicemanager.h"
-#include "filelink.h"
-#include "logger.h"
-#include "ping.h"
-#include "ping360.h"
+#include "link/filelink.h"
+#include "logger/logger.h"
+#include "sensor/ping.h"
+#include "sensor/ping360.h"
 
 PING_LOGGING_CATEGORY(DEVICEMANAGER, "ping.devicemanager");
 

--- a/src/devicemanager/devicemanager.h
+++ b/src/devicemanager/devicemanager.h
@@ -4,10 +4,11 @@
 #include <QLoggingCategory>
 #include <QThread>
 
-#include "abstractlinknamespace.h"
-#include "ping360ethernetfinder.h"
-#include "protocoldetector.h"
-#include "sensor.h"
+#include "link/abstractlinknamespace.h"
+
+#include "sensor/ping360ethernetfinder.h"
+#include "sensor/protocoldetector.h"
+#include "sensor/sensor.h"
 
 Q_DECLARE_LOGGING_CATEGORY(DEVICEMANAGER)
 

--- a/src/filemanager/CMakeLists.txt
+++ b/src/filemanager/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(
+    filemanager
+STATIC
+    filemanager.cpp
+)
+
+target_link_libraries(
+    filemanager
+PRIVATE
+    Qt5::Core
+    Qt5::Quick
+    logger
+)

--- a/src/filemanager/filemanager.cpp
+++ b/src/filemanager/filemanager.cpp
@@ -3,7 +3,7 @@
 #include <QStandardPaths>
 
 #include "filemanager.h"
-#include "logger.h"
+#include "logger/logger.h"
 
 PING_LOGGING_CATEGORY(FILEMANAGER, "ping.filemanager");
 

--- a/src/filemanager/filemanager.cpp
+++ b/src/filemanager/filemanager.cpp
@@ -24,7 +24,7 @@ FileManager::FileManager()
         if(!f->dir.exists()) {
             qCDebug(FILEMANAGER) << "Create folder" << f->dir.path();
             f->ok = rootDir.mkpath(f->dir.path());
-            qCDebug(FILEMANAGER) << (f->ok ? "Done." : ("Error while creating folder" + f->dir.path()));
+            qCDebug(FILEMANAGER) << (f->ok ? QStringLiteral("Done.") : (QStringLiteral("Error while creating folder") + f->dir.path()));
             // Something is wrong, continue with the others
             if(!f->ok) {
                 continue;

--- a/src/flash/CMakeLists.txt
+++ b/src/flash/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(
+    flash
+STATIC
+    flasher.cpp
+)
+
+target_link_libraries(
+    flash
+PRIVATE
+    Qt5::Core
+    Qt5::Gui
+    Qt5::SerialPort
+)

--- a/src/flash/flasher.cpp
+++ b/src/flash/flasher.cpp
@@ -1,5 +1,6 @@
-#include "logger.h"
 #include "flasher.h"
+
+#include "logger/logger.h"
 
 #include <QCoreApplication>
 #include <QDebug>

--- a/src/flash/flasher.h
+++ b/src/flash/flasher.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "linkconfiguration.h"
+#include "link/linkconfiguration.h"
 
 #include <QLoggingCategory>
 #include <QProcess>

--- a/src/link/CMakeLists.txt
+++ b/src/link/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_library(
+    link
+STATIC
+    abstractlink.cpp
+    filelink.cpp
+    link.cpp
+    linkconfiguration.cpp
+    logsensorstruct.cpp
+    logthread.cpp
+    ping1dsimulationlink.cpp
+    ping360simulationlink.cpp
+    sensorinfo.cpp
+    seriallink.cpp
+    simulationlink.cpp
+    tcplink.cpp
+    udplink.cpp
+    abstractlinknamespace.h
+)
+
+target_link_libraries(link
+PRIVATE
+    Qt5::Core
+    Qt5::Network
+    Qt5::SerialPort
+    Qt5::Gui
+)

--- a/src/link/logthread.cpp
+++ b/src/link/logthread.cpp
@@ -1,7 +1,8 @@
+#include "logthread.h"
+
 #include <QDebug>
 
-#include "logger.h"
-#include "logthread.h"
+#include "logger/logger.h"
 
 PING_LOGGING_CATEGORY(LOGTHREAD, "ping.logthread");
 

--- a/src/link/simulationlink.h
+++ b/src/link/simulationlink.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "abstractlink.h"
-#include "parser-ping.h"
+#include "sensor/parser-ping.h"
 
 /**
  * @brief Simulation connection class

--- a/src/logger/CMakeLists.txt
+++ b/src/logger/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(
+    logger
+STATIC
+    logger.cpp
+    loglistmodel.cpp
+)
+
+target_link_libraries(logger
+PRIVATE
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Qml
+    filemanager # for the construtor only, perhaps we should remove that dependency.
+)

--- a/src/logger/logger.cpp
+++ b/src/logger/logger.cpp
@@ -1,11 +1,10 @@
-#include "filemanager.h"
+#include "filemanager/filemanager.h"
 #include "logger.h"
 
 #include <iostream>
 #include <QDebug>
 #include <QString>
 #include <QTime>
-#include <QtConcurrent>
 #include <QColor>
 #include <QQmlEngine>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,21 +10,21 @@
     #include <KCrash>
 #endif
 
-#include "abstractlink.h"
-#include "devicemanager.h"
-#include "filemanager.h"
-#include "flasher.h"
-#include "linkconfiguration.h"
-#include "logger.h"
-#include "notificationmanager.h"
-#include "ping.h"
-#include "ping360.h"
-#include "polarplot.h"
-#include "settingsmanager.h"
-#include "sliderruler.h"
-#include "stylemanager.h"
-#include "util.h"
-#include "waterfallplot.h"
+#include "devicemanager/devicemanager.h"
+#include "filemanager/filemanager.h"
+#include "flash/flasher.h"
+#include "link/abstractlink.h"
+#include "link/linkconfiguration.h"
+#include "logger/logger.h"
+#include "notification/notificationmanager.h"
+#include "qtquickcomponents/sliderruler.h"
+#include "sensor/ping.h"
+#include "sensor/ping360.h"
+#include "settings/settingsmanager.h"
+#include "style/stylemanager.h"
+#include "util/util.h"
+#include "waterfall/polarplot.h"
+#include "waterfall/waterfallplot.h"
 
 Q_DECLARE_LOGGING_CATEGORY(mainCategory)
 

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(
+    network
+STATIC
+    networkmanager.cpp
+    networktool.cpp
+)
+
+target_link_libraries(network
+PRIVATE
+    Qt5::Core
+    Qt5::Network
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Quick
+)

--- a/src/network/networkmanager.cpp
+++ b/src/network/networkmanager.cpp
@@ -1,5 +1,6 @@
-#include "logger.h"
 #include "networkmanager.h"
+
+#include "logger/logger.h"
 
 #include <QDebug>
 #include <QJsonDocument>

--- a/src/network/networktool.cpp
+++ b/src/network/networktool.cpp
@@ -1,8 +1,10 @@
-#include "logger.h"
-#include "maddy/parser.h"
-#include "networkmanager.h"
 #include "networktool.h"
-#include "notificationmanager.h"
+#include "networkmanager.h"
+
+#include "logger/logger.h"
+#include "maddy/parser.h"
+#include "notification/notificationmanager.h"
+
 
 #include <QJsonArray>
 #include <QJsonDocument>

--- a/src/notification/CMakeLists.txt
+++ b/src/notification/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(
+    notification
+STATIC
+    notificationmanager.cpp
+    notificationmodel.cpp
+)
+
+target_link_libraries(notification
+PRIVATE
+    Qt5::Core
+    Qt5::Widgets # because of stylemanager.h
+    Qt5::Quick # because of stylemanager.h
+)

--- a/src/notification/notificationmanager.cpp
+++ b/src/notification/notificationmanager.cpp
@@ -1,6 +1,7 @@
-#include "logger.h"
 #include "notificationmanager.h"
-#include "stylemanager.h"
+
+#include "logger/logger.h"
+#include "style/stylemanager.h"
 
 #include <QDebug>
 

--- a/src/notification/notificationmanager.h
+++ b/src/notification/notificationmanager.h
@@ -2,8 +2,8 @@
 
 #include <QLoggingCategory>
 
-#include "stylemanager.h"
-#include "notificationmodel.h"
+#include "style/stylemanager.h"
+#include "notification/notificationmodel.h"
 
 class QJSEngine;
 class QQmlEngine;

--- a/src/qtquickcomponents/CMakeLists.txt
+++ b/src/qtquickcomponents/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(
+    qtquickcomponents
+STATIC
+    sliderruler.cpp
+)
+
+target_link_libraries(qtquickcomponents
+PRIVATE
+    Qt5::Core
+    Qt5::Widgets
+    Qt5::Gui
+    Qt5::Quick
+)

--- a/src/qtquickcomponents/sliderruler.cpp
+++ b/src/qtquickcomponents/sliderruler.cpp
@@ -1,5 +1,6 @@
 #include "sliderruler.h"
-#include "stylemanager.h"
+
+#include "style/stylemanager.h"
 
 // std
 #include <cmath>

--- a/src/sensor/CMakeLists.txt
+++ b/src/sensor/CMakeLists.txt
@@ -1,0 +1,24 @@
+add_library(
+    sensor
+STATIC
+    hexvalidator.cpp
+    parser-ping.cpp
+    ping.cpp
+    ping360.cpp
+    ping360ethernetfinder.cpp
+    pingsensor.cpp
+    protocoldetector.cpp
+    sensor.cpp
+    parser.h # for the moc.
+)
+
+target_link_libraries(sensor
+PRIVATE
+    Qt5::Core
+    Qt5::Network
+    Qt5::Quick
+    Qt5::SerialPort
+    Qt5::Widgets # because of stylemanager
+    Qt5::Concurrent
+    network
+)

--- a/src/sensor/ping.cpp
+++ b/src/sensor/ping.cpp
@@ -16,10 +16,10 @@
 
 #include "hexvalidator.h"
 #include "link/seriallink.h"
-#include "networkmanager.h"
-#include "networktool.h"
-#include "notificationmanager.h"
-#include "settingsmanager.h"
+#include "network/networkmanager.h"
+#include "network/networktool.h"
+#include "notification/notificationmanager.h"
+#include "settings/settingsmanager.h"
 
 Q_LOGGING_CATEGORY(PING_PROTOCOL_PING, "ping.protocol.ping")
 

--- a/src/sensor/ping.cpp
+++ b/src/sensor/ping.cpp
@@ -29,9 +29,9 @@ Ping::Ping()
     :PingSensor(PingDeviceType::PING1D)
     ,_points(_num_points, 0)
 {
-    setControlPanel({"qrc:/Ping1DControlPanel.qml"});
-    setSensorVisualizer({"qrc:/Ping1DVisualizer.qml"});
-    setSensorStatusModel({"qrc:/Ping1DStatusModel.qml"});
+    setControlPanel({QStringLiteral("qrc:/Ping1DControlPanel.qml")});
+    setSensorVisualizer({QStringLiteral("qrc:/Ping1DVisualizer.qml")});
+    setSensorStatusModel({QStringLiteral("qrc:/Ping1DStatusModel.qml")});
 
     _periodicRequestTimer.setInterval(1000);
     connect(&_periodicRequestTimer, &QTimer::timeout, this, [this] {

--- a/src/sensor/ping360.cpp
+++ b/src/sensor/ping360.cpp
@@ -17,10 +17,10 @@
 
 #include "hexvalidator.h"
 #include "link/seriallink.h"
-#include "networkmanager.h"
-#include "networktool.h"
-#include "notificationmanager.h"
-#include "settingsmanager.h"
+#include "network/networkmanager.h"
+#include "network/networktool.h"
+#include "notification/notificationmanager.h"
+#include "settings/settingsmanager.h"
 
 Q_LOGGING_CATEGORY(PING_PROTOCOL_PING360, "ping.protocol.ping360")
 

--- a/src/sensor/ping360.cpp
+++ b/src/sensor/ping360.cpp
@@ -47,9 +47,9 @@ Ping360::Ping360()
     // QVector crashs when constructed in initialization list
     _data = QVector<double>(_maxNumberOfPoints, 0);
 
-    setControlPanel({"qrc:/Ping360ControlPanel.qml"});
-    setSensorVisualizer({"qrc:/Ping360Visualizer.qml"});
-    setSensorStatusModel({"qrc:/Ping360StatusModel.qml"});
+    setControlPanel({QStringLiteral("qrc:/Ping360ControlPanel.qml")});
+    setSensorVisualizer({QStringLiteral("qrc:/Ping360Visualizer.qml")});
+    setSensorStatusModel({QStringLiteral("qrc:/Ping360StatusModel.qml")});
 
     connect(this, &Sensor::connectionOpen, this, &Ping360::startPreConfigurationProcess);
 

--- a/src/sensor/ping360ethernetfinder.h
+++ b/src/sensor/ping360ethernetfinder.h
@@ -3,7 +3,7 @@
 #include <QTimer>
 #include <QUdpSocket>
 
-#include "linkconfiguration.h"
+#include "link/linkconfiguration.h"
 
 /**
  * @brief This class will scan the network for Ping360 devices

--- a/src/sensor/pingsensor.cpp
+++ b/src/sensor/pingsensor.cpp
@@ -1,5 +1,7 @@
-#include "logger.h"
 #include "pingsensor.h"
+
+#include "logger/logger.h"
+
 #include "ping-message-common.h"
 #include "ping-message-ping1d.h"
 

--- a/src/sensor/protocoldetector.cpp
+++ b/src/sensor/protocoldetector.cpp
@@ -1,3 +1,5 @@
+#include "protocoldetector.h"
+
 #include <QtConcurrent>
 #include <QDebug>
 #include <QFuture>
@@ -10,7 +12,6 @@
 #include <ping-message.h>
 #include <ping-message-common.h>
 #include <ping-message-ping1d.h>
-#include "protocoldetector.h"
 
 Q_LOGGING_CATEGORY(PING_PROTOCOL_PROTOCOLDETECTOR, "ping.protocol.protocoldetector")
 

--- a/src/sensor/protocoldetector.h
+++ b/src/sensor/protocoldetector.h
@@ -2,8 +2,8 @@
 
 #include <QThread>
 
-#include "abstractlink.h"
-#include "linkconfiguration.h"
+#include "link/abstractlink.h"
+#include "link/linkconfiguration.h"
 #include "parser-ping.h"
 
 class QSerialPortInfo;

--- a/src/sensor/sensor.cpp
+++ b/src/sensor/sensor.cpp
@@ -1,10 +1,11 @@
+#include "sensor.h"
+
 #include <QDateTime>
 #include <QDebug>
 #include <QLoggingCategory>
 
-#include "filelink.h"
-#include "filemanager.h"
-#include "sensor.h"
+#include "link/filelink.h"
+#include "filemanager/filemanager.h"
 
 #include <ping-message.h>
 #include <ping-message-common.h>

--- a/src/sensor/sensor.h
+++ b/src/sensor/sensor.h
@@ -4,11 +4,12 @@
 #include <QQuickItem>
 #include <QPointer>
 
-#include "flasher.h"
-#include "link.h"
+#include "flash/flasher.h"
+#include "link/link.h"
+#include "link/sensorinfo.h"
+
 #include "parser.h"
 #include "protocoldetector.h"
-#include "sensorinfo.h"
 
 // TODO: rename to Device?
 /**

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(
+    settings
+SHARED
+    qjsonsettings.cpp
+    settingsmanager.cpp
+    varianttree.cpp
+)
+
+target_link_libraries(settings
+PRIVATE
+    Qt5::Core
+    Qt5::Qml
+    Qt5::Widgets # because of QColor
+)

--- a/src/settings/settingsmanager.cpp
+++ b/src/settings/settingsmanager.cpp
@@ -1,5 +1,6 @@
-#include "logger.h"
 #include "settingsmanager.h"
+
+#include "logger/logger.h"
 
 #include <QQmlEngine>
 

--- a/src/settings/settingsmanager.h
+++ b/src/settings/settingsmanager.h
@@ -4,10 +4,11 @@
 #include <QSettings>
 #include <QStringListModel>
 
-#include "linkconfiguration.h"
-#include "qjsonsettings.h"
-#include "settingsmanagerhelper.h"
-#include "varianttree.h"
+#include "link/linkconfiguration.h"
+
+#include "settings/qjsonsettings.h"
+#include "settings/settingsmanagerhelper.h"
+#include "settings/varianttree.h"
 
 class QJSEngine;
 class QQmlEngine;

--- a/src/style/CMakeLists.txt
+++ b/src/style/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(
+    style
+STATIC
+    stylemanager.cpp
+)
+
+target_link_libraries(style
+PRIVATE
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Qml
+)

--- a/src/style/stylemanager.cpp
+++ b/src/style/stylemanager.cpp
@@ -1,6 +1,7 @@
-#include "logger.h"
-#include "settingsmanager.h"
 #include "stylemanager.h"
+
+#include "logger/logger.h"
+#include "settings/settingsmanager.h"
 
 #include <QDebug>
 #include <QGuiApplication>

--- a/src/style/stylemanager.h
+++ b/src/style/stylemanager.h
@@ -5,7 +5,7 @@
 #include <QLoggingCategory>
 #include <QQmlApplicationEngine>
 
-#include "pingproperties.h"
+#include "util/pingproperties.h"
 
 class QJSEngine;
 class QQmlEngine;

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(
+    util
+STATIC
+    util.cpp
+)
+
+target_link_libraries(util
+PRIVATE
+    Qt5::Core
+    Qt5::Widgets
+    Qt5::Charts
+    Qt5::SerialPort
+)

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -1,8 +1,9 @@
+#include "util.h"
+
 #include <QSerialPortInfo>
 #include <QtCharts/QXYSeries>
 
-#include "logger.h"
-#include "util.h"
+#include "logger/logger.h"
 
 PING_LOGGING_CATEGORY(util, "ping.util");
 

--- a/src/waterfall/CMakeLists.txt
+++ b/src/waterfall/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(
+    waterfall
+STATIC
+    polarplot.cpp
+    waterfall.cpp
+    waterfallgradient.cpp
+    waterfallplot.cpp
+)
+
+target_link_libraries(
+    waterfall
+    PRIVATE
+    Qt5::Quick
+    logger
+    )

--- a/src/waterfall/polarplot.cpp
+++ b/src/waterfall/polarplot.cpp
@@ -1,12 +1,12 @@
-#include "filemanager.h"
+#include "filemanager/filemanager.h"
 #include "polarplot.h"
 
 #include <limits>
 
-#include <QtConcurrent>
 #include <QPainter>
 #include <QtMath>
 #include <QVector>
+#include <QTimer>
 
 PING_LOGGING_CATEGORY(polarplot, "ping.polarplot")
 

--- a/src/waterfall/polarplot.h
+++ b/src/waterfall/polarplot.h
@@ -3,7 +3,8 @@
 #include <QQuickPaintedItem>
 #include <QImage>
 
-#include "logger.h"
+#include "logger/logger.h"
+
 #include "ringvector.h"
 #include "waterfall.h"
 #include "waterfallgradient.h"

--- a/src/waterfall/waterfall.cpp
+++ b/src/waterfall/waterfall.cpp
@@ -1,9 +1,10 @@
-#include "filemanager.h"
+#include "filemanager/filemanager.h"
+#include "logger/logger.h"
+
 #include "waterfall.h"
 
 #include <limits>
 
-#include <QtConcurrent>
 #include <QPainter>
 #include <QtMath>
 #include <QVector>

--- a/src/waterfall/waterfall.h
+++ b/src/waterfall/waterfall.h
@@ -3,7 +3,6 @@
 #include <QQuickPaintedItem>
 #include <QImage>
 
-#include "logger.h"
 #include "ringvector.h"
 #include "waterfallgradient.h"
 

--- a/src/waterfall/waterfallgradient.cpp
+++ b/src/waterfall/waterfallgradient.cpp
@@ -4,6 +4,7 @@
 #include <QtDebug>
 
 #include "waterfallgradient.h"
+#include "logger/logger.h"
 
 PING_LOGGING_CATEGORY(waterfallGradient, "ping.waterfallGradient")
 

--- a/src/waterfall/waterfallgradient.h
+++ b/src/waterfall/waterfallgradient.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include <QLinearGradient>
-#include <QtDebug>
-
-#include "logger.h"
+#include <QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(waterfallGradient)
 

--- a/src/waterfall/waterfallplot.cpp
+++ b/src/waterfall/waterfallplot.cpp
@@ -1,12 +1,14 @@
-#include "filemanager.h"
 #include "waterfallplot.h"
+
+#include "filemanager/filemanager.h"
+#include "logger/logger.h"
 
 #include <limits>
 
-#include <QtConcurrent>
 #include <QPainter>
 #include <QtMath>
 #include <QVector>
+#include <QTimer>
 
 PING_LOGGING_CATEGORY(waterfallplot, "ping.waterfallplot")
 

--- a/src/waterfall/waterfallplot.h
+++ b/src/waterfall/waterfallplot.h
@@ -3,7 +3,6 @@
 #include <QQuickPaintedItem>
 #include <QImage>
 
-#include "logger.h"
 #include "ringvector.h"
 #include "waterfall.h"
 #include "waterfallgradient.h"


### PR DESCRIPTION
Initial port of ping-viewer to CMake, it builds, and we can see a few problems with the dependency graph of the software by looking at the libraries that each internal library links against. I also added a few forced defines to CMake to block some misuse of Qt, and because of that I had to work thru the headers and code.