### PR TITLE
Fix mouse range in polarplot

### DIFF
--- a/src/waterfall/polarplot.cpp
+++ b/src/waterfall/polarplot.cpp
@@ -63,9 +63,6 @@ void PolarPlot::setImage(const QImage &image)
 void PolarPlot::draw(const QVector<double>& points, float angle, float initPoint, float length, float angleGrad,
                      float sectorSize)
 {
-    Q_UNUSED(initPoint)
-    Q_UNUSED(length)
-
     static const QPoint center(_image.width()/2, _image.height()/2);
     static const float degreeToRadian = M_PI/180.0f;
     static const float gradianToRadian = M_PI/200.0f;

--- a/src/waterfall/polarplot.cpp
+++ b/src/waterfall/polarplot.cpp
@@ -146,7 +146,7 @@ void PolarPlot::updateMouseColumnData()
     _mouseSampleAngle = grad*grad2deg;
 
     // Calculate mouse distance in meters
-    _mouseSampleDistance = std::hypotf(delta.x(), delta.y())*_maxDistance*1e-3;
+    _mouseSampleDistance = std::hypotf(delta.x(), delta.y())*_maxDistance;
 
     emit mouseSampleAngleChanged();
     emit mouseSampleDistanceChanged();


### PR DESCRIPTION
The distance value was multiplied by 1e-3 unnecessary 
![image](https://user-images.githubusercontent.com/1215497/63295591-6adf7d00-c2a3-11e9-84b5-aea3f74047a8.png)
