### PR TITLE
pingslider: dont enable controls when not visible

### DIFF
--- a/qml/PingSlider.qml
+++ b/qml/PingSlider.qml
@@ -38,7 +38,7 @@ RowLayout {
         wheelEnabled: true
         from: root.from
         to: root.to
-
+        enabled: visible
         background: SliderRuler {
             id: ticks
             anchors.fill: parent
@@ -67,6 +67,7 @@ RowLayout {
         to: root.to
         stepSize: sliderControl.stepSize
         editable: true
+        enabled: visible
     }
 
     Binding on value {


### PR DESCRIPTION
Theres a bud in qml that's activating some controls even when they
are not visible in the scene