### PR TITLE
polarplot: Add background color compatible with theme

### DIFF
--- a/src/waterfall/polarplot.h
+++ b/src/waterfall/polarplot.h
@@ -105,23 +105,27 @@ private:
     Q_DISABLE_COPY(PolarPlot)
 
     /**
-     * @brief Load user gradients
-     *
-     */
-    void loadUserGradients();
-
-    /**
      * @brief Update mouse column information
      *
      */
     void updateMouseColumnData();
 
+    /**
+     * @brief Update mask variable to remove unnecessary pixels
+     *  outside the main area.
+     *  For this plot, the mask is a full circle.
+     *
+     */
+    void updateMask();
+
+    QImage _backgroundImage;
     QVector<float> _distances;
     QImage _image;
     float _maxDistance;
     float _mouseSampleAngle;
     float _mouseSampleDistance;
     QPainter *_painter;
+    QPainterPath _polarBackgroundMask;
     static uint16_t _angularResolution;
     QTimer* _updateTimer;
 };


### PR DESCRIPTION
This allows a better visualization of the plot and the head indicator
Fix #703

![image](https://user-images.githubusercontent.com/1215497/63521787-7910e180-c4cd-11e9-95be-c785013d5a4c.png)


Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>