### PR TITLE
Revert "ping360: Change scalar from 2 to 4 in sample period calculation"

### DIFF
--- a/src/sensor/ping360.cpp
+++ b/src/sensor/ping360.cpp
@@ -454,7 +454,7 @@ void Ping360::stopConfiguration()
 
 uint16_t Ping360::calculateSamplePeriod(float distance)
 {
-    float calculatedSamplePeriod = 4.0f*distance/(_num_points*_speed_of_sound*_samplePeriodTickDuration);
+    float calculatedSamplePeriod = 2.0f*distance/(_num_points*_speed_of_sound*_samplePeriodTickDuration);
     if(qFuzzyIsNull(calculatedSamplePeriod) || calculatedSamplePeriod < 0
             || calculatedSamplePeriod > std::numeric_limits<uint16_t>::max()) {
         qCWarning(PING_PROTOCOL_PING360) << "Invalid calculation of sample period. Going to use firmware default values.";


### PR DESCRIPTION
This was done wrong, the multiplication was done in the `sample_period` it should be applied in pulse length.
This reverts commit 520ea4edac5fd4a720f48f9777785a067f331d78.
