### PR TITLE
ping360: Remove reverse_direction when back to full scan

### DIFF
--- a/src/sensor/ping360.h
+++ b/src/sensor/ping360.h
@@ -323,6 +323,10 @@ public:
         int sectorSizeGrad = round(sectorSize * 400/360.0);
 
         if(_sectorSize != sectorSizeGrad) {
+            // Reset reverse direction when back to full scan
+            if(sectorSizeGrad == 400) {
+                _reverse_direction = false;
+            }
             _sectorSize = sectorSizeGrad;
             emit sectorSizeChanged();
         }


### PR DESCRIPTION
Fix #719 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>