### PR TITLE
Fix manual connection

### DIFF
--- a/qml/ConnectionMenu.qml
+++ b/qml/ConnectionMenu.qml
@@ -13,6 +13,7 @@ Item {
     id: root
     property var ping: null
     property var serialPortList: null
+    signal closeRequest()
 
     Connections {
         target: ping
@@ -218,6 +219,7 @@ Item {
                             break
                     }
                     DeviceManager.connectLinkDirectly(connectionType, connectionConf, connectionDevice)
+                    closeRequest()
                 }
             }
         }

--- a/qml/DeviceManagerViewer.qml
+++ b/qml/DeviceManagerViewer.qml
@@ -35,15 +35,7 @@ PingPopup {
                 onClicked: {
                     print(stack.depth)
                     if(stack.depth == 1) {
-                        stack.push(
-                            Qt.createComponent(
-                                "qrc:/ConnectionMenu.qml"
-                            ).createObject(stack, {
-                                "ping": Qt.binding(function() { return DeviceManager.primarySensor}),
-                                "width": Qt.binding(function() { return stack.width}),
-                                "height": Qt.binding(function() { return stack.height})
-                            })
-                        )
+                        stack.push(connectionMenu)
                     } else {
                         stack.pop()
                     }
@@ -54,6 +46,18 @@ PingPopup {
                 text: "Cancel"
                 Layout.fillWidth: true
                 onClicked: root.close()
+            }
+        }
+    }
+
+    Component {
+        id: connectionMenu
+        ConnectionMenu {
+            ping: DeviceManager.primarySensor
+            width: stack.width
+            height: stack.height
+            onCloseRequest: {
+                root.close()
             }
         }
     }


### PR DESCRIPTION
After a manual connection is done and the ping is connected, the UI is still apppearing, and there's a button `cancel` - that's really not what should happen as cancel means something in the lines of cancel manual connection or cancel active connection. This patch fixes two things: 
- Closes the UI after a successfull connection
- Fixes the way we created the ConnectionsMenu 