### PR TITLE
ping360: Improve timeout logic

### DIFF
--- a/src/sensor/ping360.h
+++ b/src/sensor/ping360.h
@@ -555,6 +555,9 @@ private:
     static const uint16_t _viewerDefaultTransmitFrequency;
     static const uint16_t _viewerDefaultNumberOfSamples;
 
+    // Physical properties of the sensor
+    static const float _angularSpeedGradPerMs;
+
     uint16_t _angle = 200;
     uint16_t _transmit_duration = _firmwareDefaultTransmitDuration;
     uint32_t _gain_setting = _firmwareDefaultGainSetting;
@@ -591,6 +594,8 @@ private:
     int _maxNumberOfPoints = 2048;
     // The sensor can take 4s to answer, we are also using an extra 200ms for latency
     int _sensorTimeout = 4200;
+    // The sensor will reset the position after 30s without communication
+    int _sensorRestartTimeoutMs = 30000;
 
     // Sector size in gradians, default is full circle
     int _sectorSize = 400;


### PR DESCRIPTION
Use the angular speed plus the network delay to calculate the next probable timeout
Go back to the 4.2s WCS timeout after a 30s communication loss

Fix #747 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>