### PR TITLE
Find ping360 on secondary network

### DIFF
--- a/src/sensor/ping360ethernetfinder.cpp
+++ b/src/sensor/ping360ethernetfinder.cpp
@@ -19,6 +19,7 @@ void Ping360EthernetFinder::doBroadcast()
     // described in the communications manual.
     QByteArray datagram = "Discovery";
     _broadcastSocket.writeDatagram(datagram, QHostAddress::Broadcast, 30303);
+    _broadcastSocket.writeDatagram(datagram, QHostAddress("192.168.2.255"), 30303);
 }
 
 void Ping360EthernetFinder::processBroadcastResponses()


### PR DESCRIPTION
Broadcasting to 255.255.255.255 finds only responses from the default network interface (usually your router). With this patch we find it on the default interface + 192.168.2.x in case there are two network interfaces.