### PR TITLE
qjsonsettings: Add missing const in parameter

### DIFF
--- a/src/settings/qjsonsettings.cpp
+++ b/src/settings/qjsonsettings.cpp
@@ -101,7 +101,7 @@ QJsonObject QJsonSettings::object(int index) const
     return _rootValue.toArray().at(index).toObject();
 }
 
-QJsonObject QJsonSettings::object(QString& key) const
+QJsonObject QJsonSettings::object(const QString& key) const
 {
     int size = _rootValue.toArray().size();
     for(int i = 0; i < size; i++) {

--- a/src/settings/qjsonsettings.h
+++ b/src/settings/qjsonsettings.h
@@ -116,7 +116,7 @@ public:
      * @param key
      * @return Q_INVOKABLE object
      */
-    Q_INVOKABLE QJsonObject object(QString& key) const;
+    Q_INVOKABLE QJsonObject object(const QString& key) const;
 
 private:
     Q_DISABLE_COPY(QJsonSettings)


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>