### PR TITLE
Fix todos:  encapsulate ping common variables

### DIFF
--- a/src/sensor/ping.h
+++ b/src/sensor/ping.h
@@ -421,7 +421,6 @@ private:
 
     /**
      * @brief Reset sensor local variables
-     *  TODO: This variables should be moved to a structure
      *
      */
     void resetSensorLocalVariables();

--- a/src/sensor/pingsensor.cpp
+++ b/src/sensor/pingsensor.cpp
@@ -41,13 +41,13 @@ void PingSensor::handleMessagePrivate(const ping_message& msg)
 {
     qCDebug(PING_PROTOCOL_PINGSENSOR) << "Handling Message:" << msg.message_id();
 
-    if(_dstId != msg.destination_device_id()) {
-        _dstId = msg.destination_device_id();
+    if(_commonVariables.dstId != msg.destination_device_id()) {
+        _commonVariables.dstId = msg.destination_device_id();
         emit dstIdUpdate();
     }
 
-    if(_srcId != msg.source_device_id()) {
-        _srcId = msg.source_device_id();
+    if(_commonVariables.srcId != msg.source_device_id()) {
+        _commonVariables.srcId = msg.source_device_id();
         emit srcIdUpdate();
     }
 
@@ -62,16 +62,16 @@ void PingSensor::handleMessagePrivate(const ping_message& msg)
     case CommonId::NACK: {
         common_nack nackMessage{msg};
         qCCritical(PING_PROTOCOL_PINGSENSOR) << "Sensor NACK!";
-        _nack_msg = QString("%1: %2").arg(nackMessage.nack_message()).arg(nackMessage.nacked_id());
-        qCDebug(PING_PROTOCOL_PINGSENSOR) << "NACK message:" << _nack_msg;
+        _commonVariables.nack_msg = QString("%1: %2").arg(nackMessage.nack_message()).arg(nackMessage.nacked_id());
+        qCDebug(PING_PROTOCOL_PINGSENSOR) << "NACK message:" << _commonVariables.nack_msg;
         emit nackMsgUpdate();
         break;
     }
 
     // needs dynamic-payload patch
     case CommonId::ASCII_TEXT: {
-        _ascii_text = common_ascii_text(msg).ascii_message();
-        qCInfo(PING_PROTOCOL_PINGSENSOR) << "Sensor status:" << _ascii_text;
+        _commonVariables.ascii_text = common_ascii_text(msg).ascii_message();
+        qCInfo(PING_PROTOCOL_PINGSENSOR) << "Sensor status:" << _commonVariables.ascii_text;
         emit asciiTextUpdate();
         break;
     }
@@ -79,11 +79,11 @@ void PingSensor::handleMessagePrivate(const ping_message& msg)
     case CommonId::DEVICE_INFORMATION: {
         common_device_information m(msg);
 
-        _device_type = m.device_type();
-        _device_revision = m.device_revision();
-        _firmware_version_major = m.firmware_version_major();
-        _firmware_version_minor = m.firmware_version_minor();
-        _firmware_version_patch = m.firmware_version_patch();
+        _commonVariables.device_type = m.device_type();
+        _commonVariables.device_revision = m.device_revision();
+        _commonVariables.firmware_version_major = m.firmware_version_major();
+        _commonVariables.firmware_version_minor = m.firmware_version_minor();
+        _commonVariables.firmware_version_patch = m.firmware_version_patch();
 
         emit deviceTypeUpdate();
         emit deviceRevisionUpdate();
@@ -96,9 +96,9 @@ void PingSensor::handleMessagePrivate(const ping_message& msg)
     case CommonId::PROTOCOL_VERSION: {
         common_protocol_version m(msg);
 
-        _protocol_version_major = m.version_major();
-        _protocol_version_minor = m.version_minor();
-        _protocol_version_patch = m.version_patch();
+        _commonVariables.protocol_version_major = m.version_major();
+        _commonVariables.protocol_version_minor = m.version_minor();
+        _commonVariables.protocol_version_patch = m.version_patch();
 
         emit protocolVersionMajorUpdate();
         emit protocolVersionMinorUpdate();
@@ -112,9 +112,9 @@ void PingSensor::handleMessagePrivate(const ping_message& msg)
 
         m.device_type();
         // Ping1D uses device_model as device_type to specify which sersion is it
-        _device_type = m.device_model();
-        _firmware_version_major = m.firmware_version_major();
-        _firmware_version_minor = m.firmware_version_minor();
+        _commonVariables.device_type = m.device_model();
+        _commonVariables.firmware_version_major = m.firmware_version_major();
+        _commonVariables.firmware_version_minor = m.firmware_version_minor();
 
         emit deviceTypeUpdate();
         emit firmwareVersionMajorUpdate();
@@ -133,18 +133,18 @@ void PingSensor::handleMessagePrivate(const ping_message& msg)
 void PingSensor::printStatus() const
 {
     qCDebug(PING_PROTOCOL_PINGSENSOR) << "PingSensor Status:";
-    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- srcId:" << _srcId;
-    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- dstID:" << _dstId;
-    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- device_type:" << _device_type;
-    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- device_revision:" << _device_revision;
-    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- protocol_version_major:" << _protocol_version_major;
-    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- protocol_version_minor:" << _protocol_version_minor;
-    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- protocol_version_patch:" << _protocol_version_patch;
-    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- firmware_version_major:" << _firmware_version_major;
-    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- firmware_version_minor:" << _firmware_version_minor;
-    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- firmware_version_patch:" << _firmware_version_patch;
-    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- ascii_text:" << _ascii_text;
-    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- nack_msg:" << _nack_msg;
+    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- srcId:" << _commonVariables.srcId;
+    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- dstID:" << _commonVariables.dstId;
+    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- device_type:" << _commonVariables.device_type;
+    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- device_revision:" << _commonVariables.device_revision;
+    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- protocol_version_major:" << _commonVariables.protocol_version_major;
+    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- protocol_version_minor:" << _commonVariables.protocol_version_minor;
+    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- protocol_version_patch:" << _commonVariables.protocol_version_patch;
+    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- firmware_version_major:" << _commonVariables.firmware_version_major;
+    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- firmware_version_minor:" << _commonVariables.firmware_version_minor;
+    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- firmware_version_patch:" << _commonVariables.firmware_version_patch;
+    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- ascii_text:" << _commonVariables.ascii_text;
+    qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- nack_msg:" << _commonVariables.nack_msg;
     qCDebug(PING_PROTOCOL_PINGSENSOR) << "\t- lostMessages:" << _lostMessages;
     printSensorInformation();
 }

--- a/src/sensor/pingsensor.h
+++ b/src/sensor/pingsensor.h
@@ -40,7 +40,7 @@ public:
      *
      * @return uint8_t source id
      */
-    uint8_t srcId() const { return _srcId; }
+    uint8_t srcId() const { return _commonVariables.srcId; }
     Q_PROPERTY(int srcId READ srcId NOTIFY srcIdUpdate)
 
     /**
@@ -48,7 +48,7 @@ public:
      *
      * @return uint8_t destination ID
      */
-    uint8_t dstId() const { return _dstId; }
+    uint8_t dstId() const { return _commonVariables.dstId; }
     Q_PROPERTY(int dstId READ dstId NOTIFY dstIdUpdate)
 
     //TODO: move functions from snake case to camel case
@@ -57,7 +57,7 @@ public:
      *
      * @return uint8_t firmware major version number
      */
-    uint8_t firmware_version_major() const { return _firmware_version_major; }
+    uint8_t firmware_version_major() const { return _commonVariables.firmware_version_major; }
     Q_PROPERTY(int firmware_version_major READ firmware_version_major NOTIFY firmwareVersionMajorUpdate)
 
     /**
@@ -65,7 +65,7 @@ public:
      *
      * @return uint8_t firmware minor version number
      */
-    uint16_t firmware_version_minor() const { return _firmware_version_minor; }
+    uint16_t firmware_version_minor() const { return _commonVariables.firmware_version_minor; }
     Q_PROPERTY(int firmware_version_minor READ firmware_version_minor NOTIFY firmwareVersionMinorUpdate)
 
     /**
@@ -73,7 +73,7 @@ public:
      *
      * @return uint8_t firmware patch version number
      */
-    uint16_t firmware_version_patch() const { return _firmware_version_patch; }
+    uint16_t firmware_version_patch() const { return _commonVariables.firmware_version_patch; }
     Q_PROPERTY(int firmware_version_patch READ firmware_version_patch NOTIFY firmwareVersionPatchUpdate)
 
     /**
@@ -81,7 +81,7 @@ public:
      *
      * @return uint8_t Device type number
      */
-    uint8_t device_type() const { return _device_type; }
+    uint8_t device_type() const { return _commonVariables.device_type; }
     Q_PROPERTY(int device_type READ device_type NOTIFY deviceTypeUpdate)
 
     /**
@@ -89,7 +89,7 @@ public:
      *
      * @return uint8_t Device model number
      */
-    uint8_t device_revision() const { return _device_revision; }
+    uint8_t device_revision() const { return _commonVariables.device_revision; }
     Q_PROPERTY(int device_revision READ device_revision NOTIFY deviceRevisionUpdate)
 
     /**
@@ -97,7 +97,7 @@ public:
      *
      * @return QString
      */
-    QString asciiText() const { return _ascii_text; }
+    QString asciiText() const { return _commonVariables.ascii_text; }
     Q_PROPERTY(QString ascii_text READ asciiText NOTIFY asciiTextUpdate)
 
     /**
@@ -106,7 +106,7 @@ public:
      *
      * @return QString
      */
-    QString errMsg() const { return _nack_msg; }
+    QString errMsg() const { return _commonVariables.nack_msg; }
     Q_PROPERTY(QString err_msg READ errMsg NOTIFY nackMsgUpdate)
 
     /**
@@ -197,19 +197,32 @@ protected:
      */
     void writeMessage(const ping_message& msg) const;
 
-    QString _ascii_text;
-    uint8_t _device_revision{0};
-    uint8_t _device_type{0};
-    uint8_t _dstId{0};
-    uint8_t _firmware_version_major{0};
-    uint8_t _firmware_version_minor{0};
-    uint8_t _firmware_version_patch{0};
+    // Common variables between all ping devices
+    struct CommonVariables {
+        QString ascii_text;
+        uint8_t device_revision{0};
+        uint8_t device_type{0};
+        uint8_t dstId{0};
+        uint8_t firmware_version_major{0};
+        uint8_t firmware_version_minor{0};
+        uint8_t firmware_version_patch{0};
+        QString nack_msg;
+        uint8_t protocol_version_major{0};
+        uint8_t protocol_version_minor{0};
+        uint8_t protocol_version_patch{0};
+        uint8_t srcId{0};
+
+        /**
+         * @brief Reset variables to default values
+         *
+         */
+        inline void reset()
+        {
+            *this = {};
+        }
+    } _commonVariables;
+
     int _lostMessages{0};
-    QString _nack_msg;
-    uint8_t _protocol_version_major{0};
-    uint8_t _protocol_version_minor{0};
-    uint8_t _protocol_version_patch{0};
-    uint8_t _srcId{0};
 
 private:
     Q_DISABLE_COPY(PingSensor)


### PR DESCRIPTION
Encapsulate common ping variables inside a struct, this helps to understand what is sensor variables and what is not