### PR TITLE
Force name in AbstractLink constructor 

### DIFF
--- a/src/link/abstractlink.cpp
+++ b/src/link/abstractlink.cpp
@@ -5,9 +5,10 @@
 
 const QString AbstractLink::_timeFormat = QStringLiteral("hh:mm:ss.zzz");
 
-AbstractLink::AbstractLink(QObject* parent)
+AbstractLink::AbstractLink(const QString& name, QObject* parent)
     : QObject(parent)
     , _autoConnect(false)
+    , _name(name)
     , _type(LinkType::None)
 {
     connect(this, &AbstractLink::newData, this, [&](const QByteArray& data) {

--- a/src/link/abstractlink.h
+++ b/src/link/abstractlink.h
@@ -18,9 +18,10 @@ public:
     /**
      * @brief Construct a new Abstract Link object
      *
+     * @param name
      * @param parent
      */
-    AbstractLink(QObject* parent = nullptr);
+    AbstractLink(const QString& name, QObject* parent = nullptr);
 
     /**
      * @brief Destroy the Abstract Link object

--- a/src/link/filelink.cpp
+++ b/src/link/filelink.cpp
@@ -11,7 +11,7 @@
 PING_LOGGING_CATEGORY(PING_PROTOCOL_FILELINK, "ping.protocol.filelink")
 
 FileLink::FileLink(QObject* parent)
-    : AbstractLink(parent)
+    : AbstractLink("FileLink", parent)
     , _openModeFlag(QIODevice::ReadWrite)
     , _timer()
     , _inout(&_file)

--- a/src/link/link.cpp
+++ b/src/link/link.cpp
@@ -19,7 +19,7 @@ Link::Link(LinkType linkType, QString name, QObject* parent)
 {
     switch(linkType) {
     case LinkType::None :
-        _abstractLink.reset(new AbstractLink());
+        _abstractLink.reset(new AbstractLink("AbstractLink"));
         break;
     case LinkType::File :
         _abstractLink.reset(new FileLink());

--- a/src/link/seriallink.cpp
+++ b/src/link/seriallink.cpp
@@ -20,7 +20,7 @@
 PING_LOGGING_CATEGORY(PING_PROTOCOL_SERIALLINK, "ping.protocol.seriallink")
 
 SerialLink::SerialLink(QObject* parent)
-    : AbstractLink(parent)
+    : AbstractLink("SerialLink", parent)
 {
     setType(LinkType::Serial);
 

--- a/src/link/simulationlink.cpp
+++ b/src/link/simulationlink.cpp
@@ -1,6 +1,6 @@
 #include "simulationlink.h"
 
 SimulationLink::SimulationLink(QObject* parent)
-    : AbstractLink(parent)
+    : AbstractLink("SimulationLink", parent)
 {
 }

--- a/src/link/tcplink.cpp
+++ b/src/link/tcplink.cpp
@@ -3,7 +3,7 @@
 #include "tcplink.h"
 
 TCPLink::TCPLink(QObject* parent)
-    : AbstractLink(parent)
+    : AbstractLink("TCPLink", parent)
 {
 }
 

--- a/src/link/udplink.cpp
+++ b/src/link/udplink.cpp
@@ -8,7 +8,7 @@
 PING_LOGGING_CATEGORY(PING_PROTOCOL_UDPLINK, "ping.protocol.udplink")
 
 UDPLink::UDPLink(QObject* parent)
-    : AbstractLink(parent)
+    : AbstractLink("UDPLink", parent)
     , _udpSocket(new QUdpSocket(parent))
 {
     setType(LinkType::Udp);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,7 +58,8 @@ int main(int argc, char *argv[])
     qmlRegisterSingletonType<Util>("Util", 1, 0, "Util", Util::qmlSingletonRegister);
 
     // Normal register
-    qmlRegisterType<AbstractLink>("AbstractLink", 1, 0, "AbstractLink");
+    qmlRegisterUncreatableType<AbstractLink>("AbstractLink", 1, 0, "AbstractLink",
+            "Link abstraction class can't be created.");
     qmlRegisterType<Flasher>("Flasher", 1, 0, "Flasher");
     qmlRegisterType<LinkConfiguration>("LinkConfiguration", 1, 0, "LinkConfiguration");
     qmlRegisterType<Ping>("Ping", 1, 0, "Ping");


### PR DESCRIPTION
We are helping ourselves forcing the name of the link in the constructor of an AbstractLink,
making it easier to provide the user the connection type that he's using. 
Fix #808 