### PR TITLE
ping360: Fix reset feature

### DIFF
--- a/src/sensor/ping360.cpp
+++ b/src/sensor/ping360.cpp
@@ -261,7 +261,10 @@ void Ping360::handleMessage(const ping_message& msg)
         // This properties are changed internally only when the link is not writable
         // Such information is normally sync between our application and the sensor
         // So with normal links such attribution is not necessary
-        if (!link()->isWritable()) {
+        _sensorSettings.checkValidation({deviceData.transmit_duration(), deviceData.gain_setting(),
+            deviceData.data_length(), deviceData.sample_period(), deviceData.transmit_frequency()});
+        // Everything should be valid, otherwise the sensor is not in sync
+        if (!link()->isWritable() && _sensorSettings.valid) {
             set_gain_setting(deviceData.gain_setting());
             set_transmit_duration(deviceData.transmit_duration());
             set_sample_period(deviceData.sample_period());
@@ -277,14 +280,11 @@ void Ping360::handleMessage(const ping_message& msg)
         if (nack.nacked_id() == Ping360Id::TRANSDUCER) {
             qCWarning(PING_PROTOCOL_PING360) << "transducer control was NACKED, reverting to default settings";
 
-            _gain_setting = _firmwareDefaultGainSetting;
-            if (_transmit_duration != _firmwareDefaultTransmitDuration) {
-                _transmit_duration = _firmwareDefaultTransmitDuration;
-                emit transmitDurationChanged();
-            }
-            _sample_period = _firmwareDefaultSamplePeriod;
-            _transmit_frequency = _viewerDefaultTransmitFrequency;
-            _num_points = _viewerDefaultNumberOfSamples;
+            set_gain_setting(_firmwareDefaultGainSetting);
+            set_transmit_duration(_viewerDefaultTransmitDuration);
+            set_sample_period(_viewerDefaultSamplePeriod);
+            set_transmit_frequency(_viewerDefaultTransmitFrequency);
+            set_number_of_points(_viewerDefaultNumberOfSamples);
 
             // request another transmission
             requestNextProfile();
@@ -478,14 +478,15 @@ void Ping360::stopConfiguration()
 
 uint16_t Ping360::calculateSamplePeriod(float distance)
 {
-    float calculatedSamplePeriod = 2.0f * distance / (_num_points * _speed_of_sound * _samplePeriodTickDuration);
+    float calculatedSamplePeriod
+        = 2.0f * distance / (_sensorSettings.num_points * _speed_of_sound * _samplePeriodTickDuration);
     if (qFuzzyIsNull(calculatedSamplePeriod) || calculatedSamplePeriod < 0
         || calculatedSamplePeriod > std::numeric_limits<uint16_t>::max()) {
-        qCWarning(PING_PROTOCOL_PING360)
-            << "Invalid calculation of sample period. Going to use firmware default values.";
+        qCWarning(PING_PROTOCOL_PING360) << "Invalid calculation of sample period. Going to use viewer default values.";
         qCDebug(PING_PROTOCOL_PING360) << "calculatedSamplePeriod: " << calculatedSamplePeriod
-                                       << "distance:" << distance << "_num_points" << _num_points << "_speed_of_sound"
-                                       << _speed_of_sound << "_samplePeriodTickDuration" << _samplePeriodTickDuration;
+                                       << "distance:" << distance << "_num_points" << _sensorSettings.num_points
+                                       << "_speed_of_sound" << _speed_of_sound << "_samplePeriodTickDuration"
+                                       << _samplePeriodTickDuration;
 
         return _viewerDefaultSamplePeriod;
     }
@@ -497,15 +498,14 @@ void Ping360::resetSettings()
 {
     qCDebug(PING_PROTOCOL_PING360) << "Settings will be reseted.";
 
-    _gain_setting = _firmwareDefaultGainSetting;
-    _angle = _firmwareDefaultAngle;
-    _transmit_duration = _firmwareDefaultTransmitDuration;
-    _sample_period = _firmwareDefaultSamplePeriod;
-    _transmit_frequency = _firmwareDefaultTransmitFrequency;
-    _num_points = _firmwareDefaultNumberOfSamples;
-    deltaStep(_angle_offset, false);
-
+    set_gain_setting(_firmwareDefaultGainSetting);
+    set_transmit_duration(_viewerDefaultTransmitDuration);
+    set_sample_period(_viewerDefaultSamplePeriod);
+    set_transmit_frequency(_viewerDefaultTransmitFrequency);
+    set_number_of_points(_viewerDefaultNumberOfSamples);
     // Signals will be update in the next profile, it's possible that old profiles contain older configurations
+    // Turn sensor settings invalid and let the interface handle the sync
+    _sensorSettings.valid = false;
 }
 
 Ping360::~Ping360() { updateSensorConfigurationSettings(); }

--- a/src/sensor/ping360.cpp
+++ b/src/sensor/ping360.cpp
@@ -41,6 +41,8 @@ const uint16_t Ping360::_firmwareDefaultNumberOfSamples = 1024;
 // The default transmit frequency to operate with
 const uint16_t Ping360::_viewerDefaultTransmitFrequency = 750;
 const uint16_t Ping360::_viewerDefaultNumberOfSamples = _firmwareMaxNumberOfPoints;
+const uint16_t Ping360::_viewerDefaultSamplePeriod = 88;
+const uint16_t Ping360::_viewerDefaultTransmitDuration = 11;
 
 // Physical properties of the sensor
 const float Ping360::_angularSpeedGradPerMs = 400.0f / 2400.0f;
@@ -485,7 +487,7 @@ uint16_t Ping360::calculateSamplePeriod(float distance)
                                        << "distance:" << distance << "_num_points" << _num_points << "_speed_of_sound"
                                        << _speed_of_sound << "_samplePeriodTickDuration" << _samplePeriodTickDuration;
 
-        return _firmwareDefaultSamplePeriod;
+        return _viewerDefaultSamplePeriod;
     }
 
     return static_cast<uint16_t>(calculatedSamplePeriod);

--- a/src/sensor/ping360.h
+++ b/src/sensor/ping360.h
@@ -549,6 +549,8 @@ private:
     // The default transmit frequency to operate with
     static const uint16_t _viewerDefaultTransmitFrequency;
     static const uint16_t _viewerDefaultNumberOfSamples;
+    static const uint16_t _viewerDefaultSamplePeriod;
+    static const uint16_t _viewerDefaultTransmitDuration;
 
     // Physical properties of the sensor
     static const float _angularSpeedGradPerMs;


### PR DESCRIPTION
This commit adds a tracking interface for the sensor settings,
making it possible to invalidate incoming messages and force the new
settings.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>

Fix #781 