### PR TITLE
Improve chart resolution

### DIFF
--- a/qml/Chart.qml
+++ b/qml/Chart.qml
@@ -60,7 +60,7 @@ Item {
             labelFormat: "%.1f"
             tickCount: 3
             min: 0
-            max: 300
+            max: 2000
         }
 
         ValueAxis {

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -24,7 +24,8 @@ QStringList Util::serialPortList()
 void Util::update(QtCharts::QAbstractSeries* series, const QVector<double>& points, const float initPos,
     const float finalPos, const float minPoint, const float maxPoint, const float multiplier)
 {
-    static const int numberOfPoints = 300;
+    // This value should be updated in Charts.qml to make it compatible
+    static const int numberOfPoints = 2000;
 
     // Check inputs
     if (!series || points.isEmpty()) {


### PR DESCRIPTION
I did a quick text with 1k points, as you can check here the resolution matchs:
![image](https://user-images.githubusercontent.com/1215497/68890978-c41e4780-06fe-11ea-843c-ec4eb533c1fe.png)

My display has 1080 pixels.

Fix #732 