### PR TITLE
devicemanager: Remove const from argument

### DIFF
--- a/src/devicemanager/devicemanager.cpp
+++ b/src/devicemanager/devicemanager.cpp
@@ -72,7 +72,7 @@ void DeviceManager::stopDetecting()
     _detectorThread.quit();
 }
 
-void DeviceManager::connectLink(const LinkConfiguration* linkConf)
+void DeviceManager::connectLink(LinkConfiguration* linkConf)
 {
     // Stop detector if we are going to connect with something
     stopDetecting();
@@ -123,7 +123,8 @@ void DeviceManager::connectLinkDirectly(const LinkConfiguration& linkConfigurati
     }
 
     append(linkConfiguration);
-    connectLink(&linkConfiguration);
+    std::remove_const<LinkConfiguration>::type removeConstlinkConfiguration = linkConfiguration;
+    connectLink(&removeConstlinkConfiguration);
 }
 
 void DeviceManager::connectLinkDirectly(AbstractLinkNamespace::LinkType connType, const QStringList& connString,

--- a/src/devicemanager/devicemanager.h
+++ b/src/devicemanager/devicemanager.h
@@ -59,7 +59,7 @@ public:
      *
      * @param linkConf
      */
-    Q_INVOKABLE void connectLink(const LinkConfiguration* linkConf);
+    Q_INVOKABLE void connectLink(LinkConfiguration* linkConf);
 
     /**
      * @brief Connect with link directly without protocol checks


### PR DESCRIPTION
This argument is not const for the QML frontend

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>