### PR TITLE
Use correct name for property

### DIFF
--- a/qml/PingStatus.qml
+++ b/qml/PingStatus.qml
@@ -29,7 +29,7 @@ Item {
             "RX speed (Bytes/s): " + ping.link.downSpeed,
             "Lost messages (#): " + ping.lost_messages,
             "Ascii text:\n" + ping.ascii_text,
-            "Error message:\n" + ping.err_msg,
+            "Error message:\n" + ping.nack_message,
         ] : []
 
         delegate: Text {

--- a/src/sensor/pingsensor.h
+++ b/src/sensor/pingsensor.h
@@ -100,13 +100,12 @@ public:
     Q_PROPERTY(QString ascii_text READ asciiText NOTIFY asciiTextChanged)
 
     /**
-     * @brief Return last err_msg message
-     * TODO: change function name
+     * @brief Return last nack message
      *
      * @return QString
      */
-    QString errMsg() const { return _commonVariables.nack_msg; }
-    Q_PROPERTY(QString err_msg READ errMsg NOTIFY nackMsgChanged)
+    QString nackMessage() const { return _commonVariables.nack_msg; }
+    Q_PROPERTY(QString nack_message READ nackMessage NOTIFY nackMsgChanged)
 
     /**
      * @brief Return number of parser errors


### PR DESCRIPTION
errMsg is not clear, since the message is from the nack message. 
This PR moves from errMsg to nack_message 