### PR TITLE
ping360: The offset should be in the sensor class

### DIFF
--- a/src/sensor/ping360.h
+++ b/src/sensor/ping360.h
@@ -250,7 +250,7 @@ public:
 
     /**
      * @brief Returns the angle offset from sample position
-     *  TODO: Maybe this should be in the viewer configuration and not in the sensor class
+     *
      * @return int
      */
     int angle_offset() { return _angle_offset; }


### PR DESCRIPTION
The sensor offset is a sensor property since is a physical property and can change
between models.
The offset can also be a variable when receiving heading data from the sonar.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>