### PR TITLE
settingsmanager: Remove deprecated todo

### DIFF
--- a/src/settings/settingsmanager.cpp
+++ b/src/settings/settingsmanager.cpp
@@ -11,7 +11,6 @@ SettingsManager::SettingsManager()
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
 
-    // TODO: reset settings if new version
     if (_settings.contains("reset")) {
         bool reset = _settings.value("reset").toBool();
         if (reset) {


### PR DESCRIPTION
We should support settings around the application upgrades

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>