### PR TITLE
settingsmanagerhelper: Move from deprecated qVariantFromValue to static QVariant::fromValue

### DIFF
--- a/src/settings/settingsmanagerhelper.h
+++ b/src/settings/settingsmanagerhelper.h
@@ -56,7 +56,7 @@ template <typename T> T qVariantValueOf(const QVariant& variant) { return varian
  *    void myName(myType value) {
  *        if(_myName == value) { return; }
  *        _myName = value;
- *        _settings.setValue(QStringLiteral("myName"), qVariantFromValue(value));
+ *        _settings.setValue(QStringLiteral("myName"), QVariant::fromValue(value));
  *        _settings.sync();
  *        qCDebug(SETTINGSMANAGER) << QStringLiteral("Save %1 with:").arg("myName") << value;
  *        emit myNameChanged();
@@ -88,7 +88,7 @@ public:                                                                         
             return;                                                                                                    \
         }                                                                                                              \
         _##NAME = value;                                                                                               \
-        _settings.setValue(QStringLiteral(#NAME), qVariantFromValue(value));                                           \
+        _settings.setValue(QStringLiteral(#NAME), QVariant::fromValue(value));                                         \
         _settings.sync();                                                                                              \
         qCDebug(SETTINGSMANAGER) << QStringLiteral("Save %1 with:").arg(#NAME) << value;                               \
         emit NAME##Changed();                                                                                          \


### PR DESCRIPTION
Fix Qt 5.14 warning messages

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>