### PR TITLE
linkconfiguration: Variables that are not connection specific should be ignored in tests

### DIFF
--- a/src/link/linkconfiguration.cpp
+++ b/src/link/linkconfiguration.cpp
@@ -141,8 +141,8 @@ bool operator==(const LinkConfiguration& first, const LinkConfiguration& second)
 {
     auto firstLinkconf = first.configurationStruct();
     auto secondLinkconf = second.configurationStruct();
-    return (firstLinkconf.name == secondLinkconf.name) && (firstLinkconf.type == secondLinkconf.type)
-        && (firstLinkconf.args == secondLinkconf.args) && (firstLinkconf.deviceType == secondLinkconf.deviceType);
+    return (firstLinkconf.type == secondLinkconf.type) && (firstLinkconf.args == secondLinkconf.args)
+        && (firstLinkconf.deviceType == secondLinkconf.deviceType);
 }
 
 QDebug operator<<(QDebug d, const LinkConfiguration& other)


### PR DESCRIPTION

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>