### PR TITLE
opengl: polarplot: Add missing float precision

### DIFF
--- a/qml/opengl/polarplot/fragment.glsl
+++ b/qml/opengl/polarplot/fragment.glsl
@@ -2,6 +2,10 @@
  * Based over: https://gist.github.com/KeyMaster-/2bb5e20f824241f3caef
  * Tilman Schmidt [KeyMaster-] example
  */
+
+// Set float precision
+precision mediump float;
+
 uniform sampler2D src;
 uniform float angle;
 varying vec2 coord;


### PR DESCRIPTION
Some backends does not provide a default precision for fragment shaders.

Fix #888

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>