### PR TITLE
Improve sensor detector usability 

### DIFF
--- a/qml/DeviceManagerViewer.qml
+++ b/qml/DeviceManagerViewer.qml
@@ -209,7 +209,7 @@ PingPopup {
                         Label {
                             Layout.fillWidth: true
                             horizontalAlignment: Text.AlignHCenter
-                            text: connection.typeToString() + " " + connection.createConfString()
+                            text: connection.typeToString() + " " + connection.argsAsConst()[0]
                         }
 
                         StatusIndicator {

--- a/src/devicemanager/devicemanager.cpp
+++ b/src/devicemanager/devicemanager.cpp
@@ -29,7 +29,7 @@ DeviceManager::DeviceManager()
 void DeviceManager::append(const LinkConfiguration& linkConf, const QString& deviceName, const QString& detectorName)
 {
     for (int i {0}; i < _sensors[Connection].size(); i++) {
-        auto vectorLinkConf = _sensors[Connection][i].value<QSharedPointer<LinkConfiguration>>().get();
+        const auto vectorLinkConf = _sensors[Connection][i].value<QSharedPointer<LinkConfiguration>>().get();
         if (*vectorLinkConf == linkConf) {
             qCDebug(DEVICEMANAGER) << "Connection configuration already exist for:" << _sensors[Name][i] << linkConf
                                    << linkConf.argsAsConst();
@@ -153,7 +153,7 @@ void DeviceManager::updateAvailableConnections(
     qCDebug(DEVICEMANAGER) << "Available devices:" << availableLinkConfigurations;
     // Make all connections unavailable by default
     for (int i {0}; i < _sensors[Available].size(); i++) {
-        auto linkConf = _sensors[Connection][i].value<QSharedPointer<LinkConfiguration>>();
+        const auto linkConf = _sensors[Connection][i].value<QSharedPointer<LinkConfiguration>>();
         if (linkConf->isSimulation() || _sensors[DetectorName][i] != detector) {
             continue;
         }

--- a/src/devicemanager/devicemanager.cpp
+++ b/src/devicemanager/devicemanager.cpp
@@ -50,6 +50,7 @@ void DeviceManager::append(const LinkConfiguration& linkConf, const QString& dev
     _sensors[Connected].append(false);
     _sensors[DetectorName].append(detectorName);
     _sensors[Name].append(deviceName);
+    _sensors[UnavailableCounter].append(0);
 
     const auto& indexRow = index(line);
     endInsertRows();
@@ -151,19 +152,57 @@ void DeviceManager::updateAvailableConnections(
     const QVector<LinkConfiguration>& availableLinkConfigurations, const QString& detector)
 {
     qCDebug(DEVICEMANAGER) << "Available devices:" << availableLinkConfigurations;
-    // Make all connections unavailable by default
+
     for (int i {0}; i < _sensors[Available].size(); i++) {
         const auto linkConf = _sensors[Connection][i].value<QSharedPointer<LinkConfiguration>>();
         if (linkConf->isSimulation() || _sensors[DetectorName][i] != detector) {
             continue;
         }
+
+        // Make all connections unavailable by default
         _sensors[Available][i] = false;
         const auto indexRow = index(i);
         emit dataChanged(indexRow, indexRow, _roles);
     }
 
+    // Check if the configuration already exists for a sensor
+    // Serial ports does not support multiple devices connected
+    // Some sensors, like Ping1D, can fail to answer a ABR procedure
     for (const auto& link : availableLinkConfigurations) {
-        append(link, PingHelper::nameFromDeviceType(link.deviceType()), detector);
+        const bool sameSerialDevice = std::any_of(
+            _sensors[Connection].cbegin(), _sensors[Connection].cend(), [&link](const QVariant& variantLink) {
+                const auto sensorLink = variantLink.value<QSharedPointer<LinkConfiguration>>().get();
+                qCDebug(DEVICEMANAGER) << "Device" << sensorLink
+                                       << "already already provided by a different connection:" << link;
+                return link.serialPort() == sensorLink->serialPort() && link != *sensorLink;
+            });
+
+        if (!sameSerialDevice) {
+            append(link, PingHelper::nameFromDeviceType(link.deviceType()), detector);
+        }
+    }
+
+    // We'll let the link to fail the communication attempt "a max number of fails" before making it unavailable
+    // This is necessary to avoid any problem related to automatic baud rates problem from the sensor side.
+    static const int maxNumberOfFails = 3;
+    for (int i {0}; i < _sensors[Available].size(); i++) {
+        const auto linkConf = _sensors[Connection][i].value<QSharedPointer<LinkConfiguration>>();
+        if (linkConf->isSimulation()) {
+            continue;
+        }
+
+        const auto indexRow = index(i);
+
+        // The sensor was detected, we can remove unavailable counter
+        if (_sensors[Available][i].toBool()) {
+            _sensors[UnavailableCounter][i] = 0;
+            emit dataChanged(indexRow, indexRow, _roles);
+            continue;
+        }
+        _sensors[Available][i] = _sensors[UnavailableCounter][i].toInt() < maxNumberOfFails;
+        _sensors[UnavailableCounter][i] = _sensors[UnavailableCounter][i].toInt() + 1;
+
+        emit dataChanged(indexRow, indexRow, _roles);
     }
 }
 

--- a/src/devicemanager/devicemanager.h
+++ b/src/devicemanager/devicemanager.h
@@ -179,6 +179,7 @@ private:
         Connection,
         Name,
         DetectorName,
+        UnavailableCounter,
     };
     QHash<int, QByteArray> _roleNames {
         {Available, "available"},
@@ -186,6 +187,7 @@ private:
         {Connection, "connection"},
         {Name, "name"},
         {DetectorName, "detectorName"},
+        {UnavailableCounter, "unavailableCounter"},
     };
 
     QSharedPointer<Sensor> _primarySensor;

--- a/src/link/linkconfiguration.cpp
+++ b/src/link/linkconfiguration.cpp
@@ -145,6 +145,8 @@ bool operator==(const LinkConfiguration& first, const LinkConfiguration& second)
         && (firstLinkconf.deviceType == secondLinkconf.deviceType);
 }
 
+bool operator!=(const LinkConfiguration& first, const LinkConfiguration& second) { return !(first == second); }
+
 QDebug operator<<(QDebug d, const LinkConfiguration& other)
 {
     QString text(QStringLiteral("LinkConfiguration{Name: %1, Sensor: %2, LinkType: %3, Arguments: (%4)}"));

--- a/src/link/linkconfiguration.h
+++ b/src/link/linkconfiguration.h
@@ -319,6 +319,7 @@ private:
 };
 
 bool operator==(const LinkConfiguration& first, const LinkConfiguration& second);
+bool operator!=(const LinkConfiguration& first, const LinkConfiguration& second);
 QDebug operator<<(QDebug d, const LinkConfiguration& other);
 QDataStream& operator<<(QDataStream& out, const LinkConfiguration linkConfiguration);
 QDataStream& operator>>(QDataStream& in, LinkConfiguration& linkConfiguration);

--- a/src/sensor/protocoldetector.cpp
+++ b/src/sensor/protocoldetector.cpp
@@ -68,6 +68,7 @@ void ProtocolDetector::doScan()
     // Scan until something is connected
     while (_active) {
         auto linksConf = updateLinkConfigurations(_linkConfigs);
+        qCDebug(PING_PROTOCOL_PROTOCOLDETECTOR) << "Looking for devices in:" << linksConf;
         for (LinkConfiguration& tryLinkConf : linksConf) {
             if (!_active) {
                 break;

--- a/src/sensor/protocoldetector.cpp
+++ b/src/sensor/protocoldetector.cpp
@@ -117,13 +117,9 @@ QVector<LinkConfiguration> ProtocolDetector::updateLinkConfigurations(QVector<Li
             continue;
         }
 
-        // Add valid port and baudrate
-        // Ping360 can't handle 9600 requests with 115200 request in a sort time priod
-        // TODO: Fix Ping360 is not possible, we should drop 9600 checks if 115200 returns fine
-        for (auto baud : {115200, 9600}) {
-            auto config = {portInfo.portName(), QString::number(baud)};
-            tempConfigs.append({LinkType::Serial, config, QString("Detector serial link")});
-        }
+        // By default, all sensors should deal with 115200 auto baudrate detection
+        auto config = {portInfo.portName(), QString::number(115200)};
+        tempConfigs.append({LinkType::Serial, config, QString("Detector serial link")});
     }
     return linkConfig + tempConfigs;
 }

--- a/src/sensor/protocoldetector.cpp
+++ b/src/sensor/protocoldetector.cpp
@@ -147,7 +147,7 @@ bool ProtocolDetector::checkSerial(LinkConfiguration& linkConf)
 
     port.setBaudRate(baudrate);
     port.setBreakEnabled(true);
-    QThread::usleep(500);
+    QThread::msleep(11);
     port.setBreakEnabled(false);
     QThread::msleep(11);
     port.write("UUU");


### PR DESCRIPTION
Ping1D has an unstable ABR procedure, where it fails to communicate with 115200 or 9600
in a not deterministic way.
Such problem breaks the find device logic, where Ping1D fails to answer 115200 and
answers with 9600, this will make the 9600 baud rate valid and invalidate 115200 baud rates.
Doing the connection with such baudrate, will result in a poor performance for the user.
To avoid such problem, we are going to drop 9600 baud rate and ask the user to use manual connection.
The user can also update the firmware to use the automatic baud rate feature.

We are also hiding the serial baud rate and UDP connection port, making the interface cleaner and less confure.

Since the unstable nature of the ABR detection in Ping1D,  this patch also allows the sensor to fail when being detected, the sensor can fail with this patch a max number of 3 times, after that the sensor will be considered unavailable (red circle).
