### PR TITLE
opengl: set precision only for GL_ES

### DIFF
--- a/qml/opengl/polarplot/fragment.glsl
+++ b/qml/opengl/polarplot/fragment.glsl
@@ -4,7 +4,9 @@
  */
 
 // Set float precision
-precision mediump float;
+#ifdef GL_ES
+    precision mediump float;
+#endif
 
 uniform sampler2D src;
 uniform float angle;


### PR DESCRIPTION
inspired by https://github.com/pxscene/pxCore/pull/690

fix #888 