### PR TITLE
firmware-update: Improve the instructions if the LED is blinking

### DIFF
--- a/docs/firmware-update.md
+++ b/docs/firmware-update.md
@@ -26,6 +26,13 @@ To open the device, hold it firmly, and turn the blue ring in counterclockwise d
 
 After the device is opened, turn it on and look for a blinking led on the circuit board inside of the device. If you see a blinking led, the device should be good and the firmware is running fine, you may close the device and double check the [troubleshooting instructions](http://docs.bluerobotics.com/ping-viewer/faq-and-troubleshooting/#troubleshooting).
 
+If the led is blinking:
+
+ - No recovery is necessary, the firmware is working fine
+ - Try with a different serial-USB adapter
+ - Check if the adapter is providing 5V and all connections are correct without short circuits
+ - Contact Blue Robotics support email
+
 If the led is not blinking:
 
  - Open the folder where the ping-viewer executable binary is located


### PR DESCRIPTION
There is no need to do a device recovery if the LED is blinking 
It's probably a hardware problem 