### PR TITLE
Ping360Visualizer: Fix head down configuration

### DIFF
--- a/qml/Ping360Visualizer.qml
+++ b/qml/Ping360Visualizer.qml
@@ -109,6 +109,32 @@ Item {
                 anchors.verticalCenter: ping.sectorSize > 180 ? parent.verticalCenter : parent.bottom
                 vertexShader: "qrc:/opengl/polarplot/vertex.glsl"
                 fragmentShader: "qrc:/opengl/polarplot/fragment.glsl"
+                transform: [
+                    Rotation {
+                        origin.x: shader.width / 2
+                        origin.y: shader.height / 2
+                        angle: -ping.heading * 180 / 200
+
+                        axis {
+                            x: 0
+                            y: 0
+                            z: ping.sectorSize > 180
+                        }
+
+                    },
+                    Rotation {
+                        origin.x: shader.width / 2
+                        origin.y: shader.height / 2
+                        angle: 180
+
+                        axis {
+                            x: shader.verticalFlip
+                            y: shader.horizontalFlip
+                            z: 0
+                        }
+
+                    }
+                ]
 
                 Text {
                     id: northText
@@ -204,19 +230,6 @@ Item {
                             y: waterfall.height * Math.sin(angle) / 2
                         }
 
-                    }
-
-                }
-
-                transform: Rotation {
-                    origin.x: shader.width / 2
-                    origin.y: shader.height / 2
-                    angle: -ping.heading * 180 / 200
-
-                    axis {
-                        x: shader.verticalFlip
-                        y: shader.horizontalFlip
-                        z: ping.sectorSize > 180
                     }
 
                 }


### PR DESCRIPTION
Ping360 head down configuration is not working in our current release, this fix the rotation logic with two rotation items 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>