### PR TITLE
Add option to run log with or without realtime update

### DIFF
--- a/qml/DisplaySettings.qml
+++ b/qml/DisplaySettings.qml
@@ -97,6 +97,17 @@ ColumnLayout {
                     onCheckedChanged: SettingsManager.replayMenu = checked
                 }
 
+                CheckBox {
+                    id: realTimeReplayChB
+
+                    text: "Enable real-time replay"
+                    checked: SettingsManager.realTimeReplay
+                    visible: SettingsManager.replayMenu
+                    Layout.columnSpan: 5
+                    Layout.fillWidth: true
+                    onCheckedChanged: SettingsManager.realTimeReplay = checked
+                }
+
                 Loader {
                     sourceComponent: DeviceManager.primarySensor ? DeviceManager.primarySensor.sensorVisualizer().displaySettings : null
                     Layout.columnSpan: 5

--- a/src/link/processlog.cpp
+++ b/src/link/processlog.cpp
@@ -1,5 +1,7 @@
 #include <QDebug>
 
+#include <algorithm>
+
 #include "logger.h"
 #include "processlog.h"
 
@@ -9,6 +11,8 @@ ProcessLog::ProcessLog(QObject* parent)
     : QObject(parent)
     , _logIndex(0)
     , _play(true)
+    , _replayTimeMs(0)
+    , _sleepTime(0)
     , _stop(false)
 {
 }
@@ -53,7 +57,12 @@ void ProcessLog::run()
             continue;
         }
 
-        QThread::msleep(diffMSecs);
+        _sleepTime = _replayTimeMs ? _replayTimeMs.load() : diffMSecs;
+        _sleepTime = std::min(_sleepTime.load(), diffMSecs);
+        while (_sleepTime > 0) {
+            QThread::msleep(10);
+            _sleepTime -= 10;
+        }
     }
 }
 

--- a/src/link/processlog.h
+++ b/src/link/processlog.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include <QByteArray>
 #include <QLoggingCategory>
 #include <QThread>
@@ -76,8 +78,10 @@ public:
      */
     void setPackageIndex(int index)
     {
-        if (_logIndex < _log.size())
+        if (_logIndex < _log.size()) {
             _logIndex = index;
+            _sleepTime = 0;
+        }
     }
 
     /**
@@ -88,6 +92,7 @@ public:
     {
         _play = true;
         _stop = false;
+        _sleepTime = 0;
     };
 
     /**
@@ -106,6 +111,18 @@ public:
      */
     QTime totalTime();
 
+    /**
+     * @brief Set the time between each message
+     *  Set time to 0 for real-time
+     *
+     * @param replayTimeMs
+     */
+    void setReplayTimeMs(int replayTimeMs)
+    {
+        _replayTimeMs = replayTimeMs;
+        _sleepTime = 0;
+    }
+
 signals:
     void newPackage(const QByteArray& data);
     void packageIndexChanged(int index);
@@ -119,7 +136,9 @@ private:
     };
 
     QVector<Pack> _log;
-    int _logIndex;
-    bool _play;
-    bool _stop;
+    std::atomic<int> _logIndex;
+    std::atomic<bool> _play;
+    std::atomic<int> _replayTimeMs;
+    std::atomic<int> _sleepTime;
+    std::atomic<bool> _stop;
 };

--- a/src/settings/settingsmanager.h
+++ b/src/settings/settingsmanager.h
@@ -122,6 +122,7 @@ private:
     AUTO_PROPERTY(bool, debugMode, false)
     AUTO_PROPERTY(uint, enabledCategories, 0)
     AUTO_PROPERTY(bool, logScrollLock, true)
+    AUTO_PROPERTY(bool, realTimeReplay, true)
     AUTO_PROPERTY(bool, replayMenu, false)
     AUTO_PROPERTY(bool, reset, false)
     AUTO_PROPERTY(bool, darkTheme, false)


### PR DESCRIPTION
Some people may turn on the sonar, connect with ping-viewer, but without request or starting the scanning with it, or stopping and starting ping requests, for the user to not wait this unnecessary amount of time when playing the log, it was added an option where the user will have the log processed with a maximum timeout of each message of 100ms. So, if any interval between each message is bigger than 100ms, the interface will not wait for the entire time and process the message inside the 100ms interval. 