### PR TITLE
waterfall: Use std::cbegin and std::cend over function call

### DIFF
--- a/src/waterfall/waterfall.cpp
+++ b/src/waterfall/waterfall.cpp
@@ -86,7 +86,7 @@ void Waterfall::loadUserGradients()
             qCDebug(waterfall) << "Invalid gradient file:" << fileInfo.fileName();
             continue;
         }
-        if (std::any_of(_gradients.cbegin(), _gradients.cend(),
+        if (std::any_of(std::cbegin(_gradients), std::cend(_gradients),
                 [&](const auto& gradientItem) { return gradientItem.name() == gradient.name(); })) {
             qCDebug(waterfall) << "Gradient already exist:" << gradient.name() << fileInfo.fileName();
             continue;


### PR DESCRIPTION
Goes forward Qt 6 support using newer C++ features over legacy Qt functions

Fix #899 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>