### PR TITLE
qml: PingLogger: Fix bind with Qt 5.15 where delegates can't use parent

### DIFF
--- a/qml/PingLogger.qml
+++ b/qml/PingLogger.qml
@@ -45,7 +45,7 @@ Item {
         }
 
         delegate: Row {
-            width: parent.width
+            width: listView.width
             spacing: 10
 
             Text {


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>