### PR TITLE
src: Disable test for windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,21 +74,23 @@ PRIVATE
 )
 
 # Test target
-enable_testing(true)
-add_executable(test test.cpp)
-add_test(NAME test COMMAND test)
+if(NOT WIN32)
+    enable_testing(true)
+    add_executable(test test.cpp)
+    add_test(NAME test COMMAND test)
 
-target_link_libraries(
-    test
-PRIVATE
-    Qt5::Core
-    Qt5::Qml
-    Qt5::Quick
-    Qt5::QuickControls2
-    Qt5::Charts
-    Qt5::Svg
-    Qt5::Test
-    Qt5::Widgets
-    ${INCLUDE_DIRS}
-    fmt::fmt
-)
+    target_link_libraries(
+        test
+    PRIVATE
+        Qt5::Core
+        Qt5::Qml
+        Qt5::Quick
+        Qt5::QuickControls2
+        Qt5::Charts
+        Qt5::Svg
+        Qt5::Test
+        Qt5::Widgets
+        ${INCLUDE_DIRS}
+        fmt::fmt
+    )
+endif()


### PR DESCRIPTION
There are two problems here:
 - Windows now by default it checks for tests if they are also no building
 - Windows C++ Standard **refuses** to build with private definition 

Signed-off-by: Patrick Jo Pereira <patrickelectric@gmail.com>