### PR TITLE
sensor: ping: Request a single profile before using last configuration

### DIFF
--- a/src/sensor/ping.cpp
+++ b/src/sensor/ping.cpp
@@ -407,6 +407,9 @@ void Ping::setLastPingConfiguration()
     // Load previous configuration with device id
     loadLastPingConfigurationSettings();
 
+    // Request at least a single profile to get device configuration
+    emitPing();
+
     // Print last configuration
     QString output = QStringLiteral("\nPingConfiguration {\n");
     for (const auto& key : _pingConfiguration.keys()) {


### PR DESCRIPTION
It's necessary to know the sensor configuration before changing it

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>