### PR TITLE
docs: custom gradients minor update

### DIFF
--- a/docs/display-settings.md
+++ b/docs/display-settings.md
@@ -72,4 +72,4 @@ This is an example of gradient file:
 #ff0000
 ```
 
-Where `#000000` is white (low power signal - 0.0), `#ffffff` (average power signal - 0.5) is black and `#ff0000` is red (max power signal - 1.0).
+Where `#000000` is black (low power signal - 0.0), `#ffffff` (average power signal - 0.5) is white and `#ff0000` is red (max power signal - 1.0).

--- a/docs/display-settings.md
+++ b/docs/display-settings.md
@@ -67,9 +67,9 @@ The user can create his own gradients for the waterfall, for this, it's necessar
 This is an example of gradient file:
 ```
 ; Put this example in a file called `Gradient_test.txt` in **Waterfall_Gradients**.
-#000000
+#7f000000
 #ffffff
 #ff0000
 ```
 
-Where `#000000` is black (low power signal - 0.0), `#ffffff` (average power signal - 0.5) is white and `#ff0000` is red (max power signal - 1.0).
+Where `#7f000000` is black with 50% transparency (low power signal - 0.0), `#ffffff` (average power signal - 0.5) is white and `#ff0000` is red (max power signal - 1.0).


### PR DESCRIPTION
- Fix #993
- add example of gradient colour with transparency
- show that custom gradient file doesn't need consistent colour formats across lines