### PR TITLE
Multi window

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -10,6 +10,12 @@ import StyleManager 1.0
 ApplicationWindow {
     id: window
 
+    signal requestNewWindow()
+    Shortcut {
+        sequence: StandardKey.New
+        onActivated: requestNewWindow()
+    }
+
     function createTitle() {
         var applicationName = "Ping Viewer";
         var versionInfo = GitTag;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ configure_file(
 set(SOURCES
     MACOSX_BUNDLE
     main.cpp
+    runguard.cpp
     ${APP_ICON}
     ${WINDOWS_RC_FILE}
     ${RESOURCES}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,8 @@
 #include <QQuickStyle>
 #include <QRegularExpression>
 
+#include <iostream>
+
 #if defined(QT_DEBUG) && defined(Q_OS_WIN)
 #include <KCrash>
 #endif
@@ -27,6 +29,7 @@
 #include "stylemanager.h"
 #include "util.h"
 #include "waterfallplot.h"
+#include "runguard.h"
 
 Q_DECLARE_LOGGING_CATEGORY(mainCategory)
 
@@ -34,6 +37,12 @@ PING_LOGGING_CATEGORY(mainCategory, "ping.main")
 
 int main(int argc, char* argv[])
 {
+    RunGuard guard( "pingviewer-app" );
+    if ( !guard.tryToRun() ) {
+        std::cerr << "Another instance of this application is already running" << std::endl;
+        return 0;
+    }
+
     // Start logger ASAP
     Logger::installHandler();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,14 +127,14 @@ int main(int argc, char* argv[])
     engine.rootContext()->setContextProperty("GitUrl", QStringLiteral(GIT_URL));
     engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
 
+    StyleManager::self()->setQmlEngine(&engine);
+
     qCInfo(mainCategory).noquote()
         << QStringLiteral("OS: %1 - %2").arg(QSysInfo::prettyProductName(), QSysInfo::productVersion());
     qCInfo(mainCategory) << "Git version:" << GIT_VERSION;
     qCInfo(mainCategory) << "Git version date:" << GIT_VERSION_DATE;
     qCInfo(mainCategory) << "Git tag:" << GIT_TAG;
     qCInfo(mainCategory) << "Git url:" << GIT_URL;
-
-    StyleManager::self()->setQmlEngine(&engine);
 
 #if defined(QT_DEBUG) && defined(Q_OS_WIN)
     // Start KCrash

--- a/src/runguard.cpp
+++ b/src/runguard.cpp
@@ -1,0 +1,80 @@
+#include "runguard.h"
+
+#include <QCryptographicHash>
+
+
+namespace
+{
+
+QString generateKeyHash( const QString& key, const QString& salt )
+{
+    QByteArray data;
+
+    data.append( key.toUtf8() );
+    data.append( salt.toUtf8() );
+    data = QCryptographicHash::hash( data, QCryptographicHash::Sha1 ).toHex();
+
+    return data;
+}
+
+}
+
+
+RunGuard::RunGuard( const QString& key )
+    : key( key )
+    , memLockKey( generateKeyHash( key, "_memLockKey" ) )
+    , sharedmemKey( generateKeyHash( key, "_sharedmemKey" ) )
+    , sharedMem( sharedmemKey )
+    , memLock( memLockKey, 1 )
+{
+    memLock.acquire();
+    {
+        QSharedMemory fix( sharedmemKey );    // Fix for *nix: http://habrahabr.ru/post/173281/
+        fix.attach();
+    }
+    memLock.release();
+}
+
+RunGuard::~RunGuard()
+{
+    release();
+}
+
+bool RunGuard::isAnotherRunning()
+{
+    if ( sharedMem.isAttached() )
+        return false;
+
+    memLock.acquire();
+    const bool isRunning = sharedMem.attach();
+    if ( isRunning )
+        sharedMem.detach();
+    memLock.release();
+
+    return isRunning;
+}
+
+bool RunGuard::tryToRun()
+{
+    if ( isAnotherRunning() )   // Extra check
+        return false;
+
+    memLock.acquire();
+    const bool result = sharedMem.create( sizeof( quint64 ) );
+    memLock.release();
+    if ( !result )
+    {
+        release();
+        return false;
+    }
+
+    return true;
+}
+
+void RunGuard::release()
+{
+    memLock.acquire();
+    if ( sharedMem.isAttached() )
+        sharedMem.detach();
+    memLock.release();
+}

--- a/src/runguard.h
+++ b/src/runguard.h
@@ -1,0 +1,32 @@
+#ifndef RUNGUARD_H
+#define RUNGUARD_H
+
+#include <QObject>
+#include <QSharedMemory>
+#include <QSystemSemaphore>
+
+
+class RunGuard
+{
+
+public:
+    RunGuard( const QString& key );
+    ~RunGuard();
+
+    bool isAnotherRunning();
+    bool tryToRun();
+    void release();
+
+private:
+    const QString key;
+    const QString memLockKey;
+    const QString sharedmemKey;
+
+    QSharedMemory sharedMem;
+    QSystemSemaphore memLock;
+
+    Q_DISABLE_COPY( RunGuard )
+};
+
+
+#endif // RUNGUARD_H


### PR DESCRIPTION
This is a WIP for the multi-window feature.

Things that we need to keep in consideration:

- ThemeManager receives only one Qml Engine, it will need to keep track of the std::vector<std::unique_ptr<QmlEngine>
- I can't test because I don't have the devices
- singleton classes could potentially bug the software since each window will need to keep track of it's own data.

Still, I can open two instances of the window from pingviewer within the same `PID`, and I can block two different applications running.


