### PR TITLE
sensor: ping: Use Common:DEVICE_INFORMATION over Ping1d::FIRMWARE_VERSION

### DIFF
--- a/src/sensor/ping.cpp
+++ b/src/sensor/ping.cpp
@@ -61,6 +61,10 @@ Ping::Ping()
         }
         emit lostMessagesChanged();
 
+        if (!_commonVariables.deviceInformation.initialized) {
+            request(CommonId::DEVICE_INFORMATION);
+        }
+
         request(Ping1dId::PCB_TEMPERATURE);
         request(Ping1dId::PROCESSOR_TEMPERATURE);
         request(Ping1dId::VOLTAGE_5);

--- a/src/sensor/ping.cpp
+++ b/src/sensor/ping.cpp
@@ -97,7 +97,7 @@ void Ping::startPreConfigurationProcess()
     request(Ping1dId::PING_ENABLE);
     request(Ping1dId::MODE_AUTO);
     request(Ping1dId::PROFILE);
-    request(Ping1dId::FIRMWARE_VERSION);
+    request(CommonId::DEVICE_INFORMATION); // We should use this over Ping1dId::FIRMWARE_VERSION
     request(Ping1dId::DEVICE_ID);
     request(Ping1dId::SPEED_OF_SOUND);
 


### PR DESCRIPTION
Enforce correct device information attribution. 