### PR TITLE
Fix log decode Python example

### DIFF
--- a/examples/decode_sensor_binary_log.py
+++ b/examples/decode_sensor_binary_log.py
@@ -80,7 +80,7 @@ class PingViewerLogReader:
     # timestamp format for recovery hh:mm:ss.xxx
     # includes optional \x00 (null byte) before every character because Windows
     TIMESTAMP_FORMAT = re.compile(
-        b'(\x00?\d){2}(\x00?:\x00?[0-5]\x00?\d){2}\x00?\.(\x00?\d){3}')
+        b'(\x00?\\d){2}(\x00?:\x00?[0-5]\x00?\\d){2}\x00?\\.(\x00?\\d){3}')
     MAX_TIMESTAMP_LENGTH = 12 * 2
 
     def __init__(self, filename: str):


### PR DESCRIPTION
### Context
Attempting to resolve [reported decoding issues](https://discuss.bluerobotics.com/t/ping-360-problem-with-decode-sensor-log/21095/4).

### Progress
- Fixed incorrect use of classmethods
- Avoided a `SyntaxWarning` from the regex definition of the timestamp format
- Handled Windows wide character encoding, for nicer printing of timestamps and the like

### Status

The remaining parsing issue is fixed by upgrading to v0.2.0 of the library (e.g. via `pip install --upgrade bluerobotics-ping`).

<details>
<summary>Parsing issue details</summary>

~Still finding and fixing errors.~

~Parsing issues are caused by ping-python not treating auto_device_data messages as variable length. That is already fixed in the codebase, so just needs to be included in a new release of that repo (@patrickelectric can we make one? 🙂). 
It is possible to confirm with `pip install git+https://github.com/bluerobotics/ping-python@deployment` if relevant.~

~This PR still fixes a problem and cleans some things up, so can be merged under that merit.~

~Parsing this [example log file](https://github.com/user-attachments/files/21614072/20250716-213500673.bin.zip) (which includes the `auto_device_data` functionality) is resulting in:~

```python
error unpacking payload: unpack requires a buffer of 20 bytes
msg_data: bytearray(b'BR\xc4\x04\xfd\x08\x02\x00\x01\x00C\x00\x0b\x00X\x00\xee\x02\x00\x00\x8f\x01\x01\x00\xb0\x04\xb0\x04C\x92\xc0\xe1\xfc\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfb\xfc\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xf8\xf0\xed\xed\xed\xed\xec\xeb\xea\xeb\xe8\xe3\xdd\xd9\xd5\xd5\xd3\xcf\xc9\xc6\xc2\xbe\xbc\xbe\xbe\xbd\xbb\xb7\xb2\xa9\xa6\xa6\xa6\xa7\xa9\xab\xac\xb0\xb2\xb2\xaf\xac\xa7\xa0\x9f\xa0\xa0\x9e\x9a\x9b\x9b\x9d\xa0\xa1\x9f\x9e\x9c\x9a\x98\x91\x87\x7f|zxyyzyywtqj^W[agjmooli`RNOPPTUQNHKLLJECA==<<=:8700/.3656664-+.5=DJLJE;<?CFD?=89;<=<@DILPNG?>@EJPUWXXTOCCDGKKMPQTXZ\\\\\\XQOLLLGD;6447651--,.,,(#$! \x1d\x1d\x1c\x19\x1b\x1b\x1b\x1b\x16\x16\x17\x16\x1b\x1b\x1d\x1f"\',157:<==:860,$ \x1f\x19\x18\x19\x1e#).26732,$\x1f!\x1e\x1f\x1c\x17\x16\x16\x1c"%(,..,+$!\x1b\x19\x1c!"#$!\x1b\x17\x14\x13\x13\x0f\x0e\x11\x16\x16\x14\x0f\x0b\x08\t\x0c\r\r\n\t\t\t\x0c\r\t\x07\r\x13\x17\x1d#(**($\x1c\x17\x10\n\x07\x08\x04\x04\x01\x06\r\x13\x14\x17\x18\x17\x16\x12\x15\x15\x17\x19\x1c\x1f\x1f!#"""##!\x1e\x1b\x1c\x1c\x1b\x18\x15\x0e\x08\x03\x00\x00\x00\x00\x01\x07\r\x10\x11\x10\x10\x13\x18\x1e""##%$\x1d\x15\x0e\x10\r\x0e\x0b\t\x05\x05\x08\n\x0c\x0e\n\r\x0b\t\x07\x03\x04\x08\x07\x06\x07\x02\x04\x06\x0b\x0e\x11\x15\x1b\x1d \x1f\x1b\x1b\x15\x13\x14\x14\x11\x13\x13\x16\x1b\x1e#$$#!\x1e\x13\x0b\x08\t\t\x0e\x0f\x13\x12\x14\x14\x17\x1b\x1d\x1f\x1f ""$&%&%%\'&%%$$$&$ " "!\x1f\x1e\x1f\x1c\x1c\x1d\x1e \x1d\x1c\x19\x17\x13\x10\n\x06\x06\x07\r\x16\x1e""\x1d\x14\x0c\x05\x00\x00\x00\x02\t\x0e\x16 %((%\x1e\x17\x15\x0f\x08\x07\t\x0e\x13\x16\x18\x17\x17\x17\x18\x1b\x1b\x1b\x17\x16\x15\x19\x1e!#%%%"\x1b\x18\x19\x1d\x1e   "!\x1b\x19\x13\x10\x14\x14\x14\x10\r\x08\x05\x02\x05\x02\x00\x02\x02\x00\x02\x00\x00\x04\x0c\x14\x1b\x1e\x1c\x1d\x1c\x1b\x15\r\r\n\r\x0f\x12\x15\x19\x1e$\'&&%\'(%" "!\x1b\x14\x10\x08\t\t\x0c\x0f\x10\t\x07\x08\x06\t\t\x07\x06\x02\x04\x04\x07\x05\x01\x01\x04\x05\n\r\x0f\x0e\n\x07\t\x0e\x15\x1c ##"!!#&$"\x1e\x18\x14\x10\x0c\t\x04\x01\x03\x05\x06\x03\x00\x00\x00\x00\x00\x00\x01\x03\x06\r\x13\x1b\x1d!#&*-034543.%\x1e\x1d\x1f!""$&)*))%"\x1e\x16\x13\x14\x18\x1c #"#!"  \x1e\x19\x17\x13\r\n\x06\x05\x08\n\x0f\x10\x0e\t\x07\t\r\x10\x13\x13\x11\x12\x10\x11\x10\x0f\x0e\x0e\n\x08\t\x0c\x0b\x0b\x07\x06\t\n\n\x05\x02\x01\x00\x01\x02\x00\x00\x01\x03\x08\x08\x06\x04\x05\x04\x04\x02\x03\x00\x00\x02\x04\x03\x01\x00\x00\x00\x00\x00\x03\x07\r\x10\x12\x13\x10\x0e\n\x07\x05\x03\x00\x02\x00\x00\x02\x02\x04\x06\x07\x07\x05\x00\x00\x00\x00\x00\x02\x06\r\x10\x11\x0e\x07\x03\x02\x00\x00\x00\x00\x00\x02\x06\x07\x06\x02\x04\x06\x08\x0b\n\x0b\t\t\t\x0c\x0f\x0e\x0b\x07\x0c\x11\x11\r\x0b\t\x0c\t\x0b\x0c\x0e\x11\x14\x16\x0e\n\t\n\t\x07\x05\x04\x02\x00\x01\x03\t\x0c\x11\x12\x14\x13\x0c\x07\x06\x07\x08\x0e\x10\x12\x12\x13\x15\x15\x15\x12\x11\x0e\x0c\x10\x11\x0e\r\x0b\x10\x13\x18\x1b $())%\x1c\x17\x16\x19\x1c#),-.-,-,*)(&\'&%!\x1f\x1f!%\'*)%\x1e\x16\x12\x18\x1e&,2357541..049<>AAB=6+-29@DFIJLPSTVUSSRPMLMOQRUXXZ\\]^_``^\\VLB;52/16=DJOSUVQME?:<?DILOSRRSQRRPOMKKID:10,\'(/9@HOSTWXTPKIJMPTWY[ZYWRRRSUZ^`_[TQU\\bfilpsvvvuqkfb``_]]^bfijjhb[[^`a_`bekoruwuogflrwzxsifggeb_afiouyzxvtpmklkgggjqv{|z\x1f\x00'), header: (66, 82, 1220, 2301, 2, 0)
format: <BBHHHHHHBBHH, buf: bytearray(b'\x01\x00C\x00\x0b\x00X\x00\xee\x02\x00\x00\x8f\x01\x01\x00\xb0\x04\xb0\x04C\x92\xc0\xe1\xfc\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfb\xfc\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xf8\xf0\xed\xed\xed\xed\xec\xeb\xea\xeb\xe8\xe3\xdd\xd9\xd5\xd5\xd3\xcf\xc9\xc6\xc2\xbe\xbc\xbe\xbe\xbd\xbb\xb7\xb2\xa9\xa6\xa6\xa6\xa7\xa9\xab\xac\xb0\xb2\xb2\xaf\xac\xa7\xa0\x9f\xa0\xa0\x9e\x9a\x9b\x9b\x9d\xa0\xa1\x9f\x9e\x9c\x9a\x98\x91\x87\x7f|zxyyzyywtqj^W[agjmooli`RNOPPTUQNHKLLJECA==<<=:8700/.3656664-+.5=DJLJE;<?CFD?=89;<=<@DILPNG?>@EJPUWXXTOCCDGKKMPQTXZ\\\\\\XQOLLLGD;6447651--,.,,(#$! \x1d\x1d\x1c\x19\x1b\x1b\x1b\x1b\x16\x16\x17\x16\x1b\x1b\x1d\x1f"\',157:<==:860,$ \x1f\x19\x18\x19\x1e#).26732,$\x1f!\x1e\x1f\x1c\x17\x16\x16\x1c"%(,..,+$!\x1b\x19\x1c!"#$!\x1b\x17\x14\x13\x13\x0f\x0e\x11\x16\x16\x14\x0f\x0b\x08\t\x0c\r\r\n\t\t\t\x0c\r\t\x07\r\x13\x17\x1d#(**($\x1c\x17\x10\n\x07\x08\x04\x04\x01\x06\r\x13\x14\x17\x18\x17\x16\x12\x15\x15\x17\x19\x1c\x1f\x1f!#"""##!\x1e\x1b\x1c\x1c\x1b\x18\x15\x0e\x08\x03\x00\x00\x00\x00\x01\x07\r\x10\x11\x10\x10\x13\x18\x1e""##%$\x1d\x15\x0e\x10\r\x0e\x0b\t\x05\x05\x08\n\x0c\x0e\n\r\x0b\t\x07\x03\x04\x08\x07\x06\x07\x02\x04\x06\x0b\x0e\x11\x15\x1b\x1d \x1f\x1b\x1b\x15\x13\x14\x14\x11\x13\x13\x16\x1b\x1e#$$#!\x1e\x13\x0b\x08\t\t\x0e\x0f\x13\x12\x14\x14\x17\x1b\x1d\x1f\x1f ""$&%&%%\'&%%$$$&$ " "!\x1f\x1e\x1f\x1c\x1c\x1d\x1e \x1d\x1c\x19\x17\x13\x10\n\x06\x06\x07\r\x16\x1e""\x1d\x14\x0c\x05\x00\x00\x00\x02\t\x0e\x16 %((%\x1e\x17\x15\x0f\x08\x07\t\x0e\x13\x16\x18\x17\x17\x17\x18\x1b\x1b\x1b\x17\x16\x15\x19\x1e!#%%%"\x1b\x18\x19\x1d\x1e   "!\x1b\x19\x13\x10\x14\x14\x14\x10\r\x08\x05\x02\x05\x02\x00\x02\x02\x00\x02\x00\x00\x04\x0c\x14\x1b\x1e\x1c\x1d\x1c\x1b\x15\r\r\n\r\x0f\x12\x15\x19\x1e$\'&&%\'(%" "!\x1b\x14\x10\x08\t\t\x0c\x0f\x10\t\x07\x08\x06\t\t\x07\x06\x02\x04\x04\x07\x05\x01\x01\x04\x05\n\r\x0f\x0e\n\x07\t\x0e\x15\x1c ##"!!#&$"\x1e\x18\x14\x10\x0c\t\x04\x01\x03\x05\x06\x03\x00\x00\x00\x00\x00\x00\x01\x03\x06\r\x13\x1b\x1d!#&*-034543.%\x1e\x1d\x1f!""$&)*))%"\x1e\x16\x13\x14\x18\x1c #"#!"  \x1e\x19\x17\x13\r\n\x06\x05\x08\n\x0f\x10\x0e\t\x07\t\r\x10\x13\x13\x11\x12\x10\x11\x10\x0f\x0e\x0e\n\x08\t\x0c\x0b\x0b\x07\x06\t\n\n\x05\x02\x01\x00\x01\x02\x00\x00\x01\x03\x08\x08\x06\x04\x05\x04\x04\x02\x03\x00\x00\x02\x04\x03\x01\x00\x00\x00\x00\x00\x03\x07\r\x10\x12\x13\x10\x0e\n\x07\x05\x03\x00\x02\x00\x00\x02\x02\x04\x06\x07\x07\x05\x00\x00\x00\x00\x00\x02\x06\r\x10\x11\x0e\x07\x03\x02\x00\x00\x00\x00\x00\x02\x06\x07\x06\x02\x04\x06\x08\x0b\n\x0b\t\t\t\x0c\x0f\x0e\x0b\x07\x0c\x11\x11\r\x0b\t\x0c\t\x0b\x0c\x0e\x11\x14\x16\x0e\n\t\n\t\x07\x05\x04\x02\x00\x01\x03\t\x0c\x11\x12\x14\x13\x0c\x07\x06\x07\x08\x0e\x10\x12\x12\x13\x15\x15\x15\x12\x11\x0e\x0c\x10\x11\x0e\r\x0b\x10\x13\x18\x1b $())%\x1c\x17\x16\x19\x1c#),-.-,-,*)(&\'&%!\x1f\x1f!%\'*)%\x1e\x16\x12\x18\x1e&,2357541..049<>AAB=6+-29@DFIJLPSTVUSSRPMLMOQRUXXZ\\]^_``^\\VLB;52/16=DJOSUVQME?:<?DILOSRRSQRRPOMKKID:10,\'(/9@HOSTWXTPKIJMPTWY[ZYWRRRSUZ^`_[TQU\\bfilpsvvvuqkfb``_]]^bfijjhb[[^`a_`bekoruwuogflrwzxsifggeb_afiouyzxvtpmklkgggjqv{|z')
BBHHHHHHBBHH
Header:
    String: PingViewer sensor log file
    Version: 1
        PingViewerBuildInfo:
        hash: 06d63fe
        date: 2025-04-17T08:30:43-03:00
        tag: v2.6.0
        os:
            name: Windows 10 Version 2009
            version: 10
        
        Sensor:
        Family: 1
        Type: 2
        
    
Continue and decode received messages? [Y/n]: Y
timestamp: '00:00:03.294'
Traceback (most recent call last):
  File "~/Documents/Work/BlueRobotics/code/ping-viewer/examples/decode_sensor_binary_log.py", line 303, in <module>
    print(decoded_message)
    ~~~~~^^^^^^^^^^^^^^^^^
  File "~/Documents/Work/BlueRobotics/code/ping-viewer/examples/.venv/lib/python3.13/site-packages/brping/pingmessage.py", line 265, in __repr__
    payload_string += "\n  - " + attr + ": " + str(getattr(self, attr))
                                                   ~~~~~~~^^^^^^^^^^^^
AttributeError: 'PingMessage' object has no attribute 'mode'
```
</details>